### PR TITLE
Run coverage task instead of jacocoTestReport task after gradle test

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,11 +20,6 @@ checkstyle {
     toolVersion = '8.29'
 }
 
-test {
-    useJUnitPlatform()
-    finalizedBy jacocoTestReport
-}
-
 task coverage(type: JacocoReport) {
     sourceDirectories.from files(sourceSets.main.allSource.srcDirs)
     classDirectories.from files(sourceSets.main.output)
@@ -38,6 +33,11 @@ task coverage(type: JacocoReport) {
         html.enabled = true
         xml.enabled = true
     }
+}
+
+test {
+    useJUnitPlatform()
+    finalizedBy coverage
 }
 
 dependencies {


### PR DESCRIPTION
this allows the xml coverage report to be properly generated after testing