### PR TITLE
Add `Job` related commands

### DIFF
--- a/data.example/addressbook.json
+++ b/data.example/addressbook.json
@@ -20,7 +20,7 @@
   }, {
     "name" : "Irfan Ibrahim",
     "phone" : "92492021",
-    "email" : "irfan@example.com",
+    "email" : "irfan@stffhub.org",
     "address" : "Blk 47 Tampines Street 20, #17-35",
     "tagged" : [ "Painting" ]
   }, {
@@ -29,6 +29,6 @@
     "email" : "arjun@stffhub.org",
     "address" : "50 Collyer Quay, S049321",
     "tagged" : [ "Contract", "Aircon" ]
-  } ]
+  } ],
+  "jobs" : [ ]
 }
-

--- a/src/main/java/peoplesoft/commons/core/JobIdFactory.java
+++ b/src/main/java/peoplesoft/commons/core/JobIdFactory.java
@@ -15,4 +15,22 @@ public class JobIdFactory {
     public static String nextId() {
         return String.valueOf(++id);
     }
+
+    /**
+     * Sets the current id.
+     *
+     * @param id To set.
+     */
+    public static void setId(int id) {
+        JobIdFactory.id = id;
+    }
+
+    /**
+     * Returns the current id.
+     *
+     * @return Id.
+     */
+    public static int getId() {
+        return id;
+    }
 }

--- a/src/main/java/peoplesoft/commons/core/JobIdFactory.java
+++ b/src/main/java/peoplesoft/commons/core/JobIdFactory.java
@@ -1,0 +1,18 @@
+package peoplesoft.commons.core;
+
+/**
+ * Class to generate unique {@code JobIds}.
+ */
+public class JobIdFactory {
+    private static int id = 0;
+
+    /**
+     * Returns a unique {@code JobId}.
+     *
+     * @return JobId.
+     */
+    // TODO: currently missing functionality with serdes
+    public static String nextId() {
+        return String.valueOf(++id);
+    }
+}

--- a/src/main/java/peoplesoft/logic/commands/ClearCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/ClearCommand.java
@@ -2,8 +2,10 @@ package peoplesoft.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import peoplesoft.commons.core.JobIdFactory;
 import peoplesoft.model.AddressBook;
 import peoplesoft.model.Model;
+import peoplesoft.model.util.Employment;
 
 /**
  * Clears the address book.
@@ -18,6 +20,9 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setAddressBook(new AddressBook());
+        // Resets association and jobId
+        Employment.newInstance();
+        JobIdFactory.setId(0);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/peoplesoft/logic/commands/DeleteCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/DeleteCommand.java
@@ -9,6 +9,7 @@ import peoplesoft.commons.core.index.Index;
 import peoplesoft.logic.commands.exceptions.CommandException;
 import peoplesoft.model.Model;
 import peoplesoft.model.person.Person;
+import peoplesoft.model.util.Employment;
 
 /**
  * Deletes a person identified using it's displayed index from the database.
@@ -41,6 +42,8 @@ public class DeleteCommand extends Command {
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deletePerson(personToDelete);
+        // Deletes employment associations
+        Employment.getInstance().deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }
 

--- a/src/main/java/peoplesoft/logic/commands/EditCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/EditCommand.java
@@ -25,6 +25,7 @@ import peoplesoft.model.person.Name;
 import peoplesoft.model.person.Person;
 import peoplesoft.model.person.Phone;
 import peoplesoft.model.tag.Tag;
+import peoplesoft.model.util.Employment;
 
 /**
  * Edits the details of an existing person in the database.
@@ -83,6 +84,8 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        // Replaces employment associations
+        Employment.getInstance().editPerson(personToEdit, editedPerson);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
@@ -1,0 +1,65 @@
+package peoplesoft.logic.commands.job;
+
+import static java.util.Objects.requireNonNull;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_DURATION;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_RATE;
+
+import peoplesoft.logic.commands.Command;
+import peoplesoft.logic.commands.CommandResult;
+import peoplesoft.logic.commands.exceptions.CommandException;
+import peoplesoft.logic.parser.exceptions.ParseException;
+import peoplesoft.logic.parser.job.JobAddCommandParser;
+import peoplesoft.model.Model;
+import peoplesoft.model.job.Job;
+
+/**
+ * Adds a {@code Job} to {@code AddressBook}.
+ */
+public class JobAddCommand extends Command {
+
+    // TODO: change if needed
+    public static final String COMMAND_WORD = "job";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a job to the database. "
+        + "Parameters: "
+        + PREFIX_NAME + "NAME "
+        + PREFIX_RATE + "RATE "
+        + PREFIX_DURATION + "DURATION ";
+
+    public static final String MESSAGE_SUCCESS = "New job added: %s";
+    public static final String MESSAGE_DUPLICATE_JOB = "This job already exists in the database";
+
+    private final Job toAdd;
+
+    /**
+     * Creates a {@code JobAddCommand} to add a {@code Job} parsed from the arguments.
+     *
+     * @param args Arguments.
+     * @throws ParseException Thrown if there is an error with parsing.
+     */
+    public JobAddCommand(String args) throws ParseException {
+        requireNonNull(args);
+        System.out.println(args);
+        toAdd = new JobAddCommandParser().parse(args);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (model.hasJob(toAdd.getJobId())) {
+            throw new CommandException(MESSAGE_DUPLICATE_JOB);
+        }
+
+        model.addJob(toAdd);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof JobAddCommand // instanceof handles nulls
+            && toAdd.equals(((JobAddCommand) other).toAdd));
+    }
+}

--- a/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
@@ -40,7 +40,6 @@ public class JobAddCommand extends Command {
      */
     public JobAddCommand(String args) throws ParseException {
         requireNonNull(args);
-        System.out.println(args);
         toAdd = new JobAddCommandParser().parse(args);
     }
 

--- a/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
@@ -23,6 +23,7 @@ public class JobAddCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a job to the database. "
         + "Parameters: "
+        + "[JOBID] "
         + PREFIX_NAME + "NAME "
         + PREFIX_RATE + "RATE "
         + PREFIX_DURATION + "DURATION ";

--- a/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
@@ -1,0 +1,90 @@
+package peoplesoft.logic.commands.job;
+
+import static java.util.Objects.requireNonNull;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_INDEX;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.List;
+
+import peoplesoft.commons.core.Messages;
+import peoplesoft.commons.core.index.Index;
+import peoplesoft.logic.commands.Command;
+import peoplesoft.logic.commands.CommandResult;
+import peoplesoft.logic.commands.exceptions.CommandException;
+import peoplesoft.logic.parser.ArgumentMultimap;
+import peoplesoft.logic.parser.ParserUtil;
+import peoplesoft.logic.parser.exceptions.ParseException;
+import peoplesoft.logic.parser.job.JobAssignCommandParser;
+import peoplesoft.model.Model;
+import peoplesoft.model.job.Job;
+import peoplesoft.model.person.Person;
+import peoplesoft.model.util.Employment;
+
+/**
+ * Assigns a {@code Job} to a {@code Person}.
+ */
+public class JobAssignCommand extends Command {
+
+    //TODO: change if needed
+    public static final String COMMAND_WORD = "assign";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns a job to a person. "
+        + "Parameters: "
+        + PREFIX_NAME + "NAME (jobId) "
+        + PREFIX_INDEX + "INDEX (person) ";
+
+    public static final String MESSAGE_SUCCESS = "Assigned Job %s to %s";
+    public static final String MESSAGE_JOB_NOT_FOUND = "This job does not exist";
+
+    private String jobId;
+    private Index personIndex;
+
+    /**
+     * Creates a {@code JobAssignCommand} to assign a {@code Job} to a {@code Person}.
+     *
+     * @param args Arguments.
+     * @throws ParseException Thrown if there is an error with parsing.
+     */
+    public JobAssignCommand(String args) throws ParseException {
+        requireNonNull(args);
+        parseArgs(args);
+    }
+
+    private void parseArgs(String args) throws ParseException {
+        // TODO: Arguably does not follow SRP/LoD
+        ArgumentMultimap argumentMultimap = new JobAssignCommandParser().parse(args);
+        jobId = ParserUtil.parseString(argumentMultimap.getValue(PREFIX_NAME).get());
+        personIndex = ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_INDEX).get());
+    }
+
+    // TODO: Change implementation if needed.
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.hasJob(jobId)) {
+            throw new CommandException(MESSAGE_JOB_NOT_FOUND);
+        }
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (personIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        Person person = lastShownList.get(personIndex.getZeroBased());
+        try {
+            // TODO: This code breaks LoD.
+            Job assignedJob = model.getAddressBook().getJobList()
+                .filtered(job -> job.getJobId().equals(jobId)).get(0);
+            Employment.associate(assignedJob, person);
+        } catch (IndexOutOfBoundsException e) {
+            // Asserts that filtered list should always contain exactly the filtered element
+            assert false;
+        }
+
+        // TODO: For now just prints a list of the jobs associated with a person to console.
+        System.out.println(person.getName() + ": " + Employment.getJobs(person, model).toString());
+        return new CommandResult(String.format(MESSAGE_SUCCESS, jobId, person.getName().toString()));
+    }
+}

--- a/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
@@ -2,7 +2,6 @@ package peoplesoft.logic.commands.job;
 
 import static java.util.Objects.requireNonNull;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_INDEX;
-import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.List;
 
@@ -30,8 +29,8 @@ public class JobAssignCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns a job to a person. "
         + "Parameters: "
-        + PREFIX_NAME + "NAME (jobId) "
-        + PREFIX_INDEX + "INDEX (person) ";
+        + "JOBID "
+        + PREFIX_INDEX + "INDEX ";
 
     public static final String MESSAGE_SUCCESS = "Assigned Job %s to %s\n%s has the following jobs: %s";
     public static final String MESSAGE_JOB_NOT_FOUND = "This job does not exist";

--- a/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
@@ -33,7 +33,7 @@ public class JobAssignCommand extends Command {
         + PREFIX_NAME + "NAME (jobId) "
         + PREFIX_INDEX + "INDEX (person) ";
 
-    public static final String MESSAGE_SUCCESS = "Assigned Job %s to %s";
+    public static final String MESSAGE_SUCCESS = "Assigned Job %s to %s\n%s has the following jobs: %s";
     public static final String MESSAGE_JOB_NOT_FOUND = "This job does not exist";
 
     private String jobId;
@@ -53,7 +53,7 @@ public class JobAssignCommand extends Command {
     private void parseArgs(String args) throws ParseException {
         // TODO: Arguably does not follow SRP/LoD
         ArgumentMultimap argumentMultimap = new JobAssignCommandParser().parse(args);
-        jobId = ParserUtil.parseString(argumentMultimap.getValue(PREFIX_NAME).get());
+        jobId = ParserUtil.parseString(argumentMultimap.getPreamble());
         personIndex = ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_INDEX).get());
     }
 
@@ -76,15 +76,17 @@ public class JobAssignCommand extends Command {
         try {
             // TODO: This code breaks LoD.
             Job assignedJob = model.getAddressBook().getJobList()
-                .filtered(job -> job.getJobId().equals(jobId)).get(0);
-            Employment.associate(assignedJob, person);
+                    .filtered(job -> job.getJobId().equals(jobId)).get(0);
+            Employment.getInstance().associate(assignedJob, person);
         } catch (IndexOutOfBoundsException e) {
             // Asserts that filtered list should always contain exactly the filtered element
             assert false;
         }
 
+        List<Job> jobs = Employment.getInstance().getJobs(person, model);
+
         // TODO: For now just prints a list of the jobs associated with a person to console.
-        System.out.println(person.getName() + ": " + Employment.getJobs(person, model).toString());
-        return new CommandResult(String.format(MESSAGE_SUCCESS, jobId, person.getName().toString()));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, jobId, person.getName(),
+                person.getName(), jobs));
     }
 }

--- a/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
@@ -3,7 +3,6 @@ package peoplesoft.logic.commands.job;
 import static java.util.Objects.requireNonNull;
 
 import java.time.Duration;
-import java.util.Set;
 
 import peoplesoft.logic.commands.Command;
 import peoplesoft.logic.commands.CommandResult;
@@ -14,6 +13,7 @@ import peoplesoft.model.Model;
 import peoplesoft.model.job.Job;
 import peoplesoft.model.job.Money;
 import peoplesoft.model.job.Rate;
+import peoplesoft.model.util.Employment;
 
 /**
  * Deletes a {@code Job} with a given {@code JobId}.
@@ -54,9 +54,10 @@ public class JobDeleteCommand extends Command {
 
         try {
             Job jobToDelete = new Job(toDelete, "empty",
-                    new Rate(new Money(1), Duration.ofHours(1)), Duration.ofHours(1), false, Set.of());
+                    new Rate(new Money(1), Duration.ofHours(1)), Duration.ofHours(1), false);
             // Currently handles deletions in JobList implementation (by jobId)
             model.deleteJob(jobToDelete);
+            Employment.getInstance().deleteJob(jobToDelete);
         } catch (IndexOutOfBoundsException e) {
             // Asserts that filtered list should always contain exactly the filtered element
             assert false;

--- a/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
@@ -1,0 +1,68 @@
+package peoplesoft.logic.commands.job;
+
+import static java.util.Objects.requireNonNull;
+
+import peoplesoft.logic.commands.Command;
+import peoplesoft.logic.commands.CommandResult;
+import peoplesoft.logic.commands.exceptions.CommandException;
+import peoplesoft.logic.parser.exceptions.ParseException;
+import peoplesoft.logic.parser.job.JobDeleteCommandParser;
+import peoplesoft.model.Model;
+import peoplesoft.model.job.Job;
+
+/**
+ * Deletes a {@code Job} with a given {@code JobId}.
+ */
+public class JobDeleteCommand extends Command {
+
+    //TODO: change if needed
+    public static final String COMMAND_WORD = "jobdelete";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Deletes the job identified by the job ID.\n"
+        + "Parameters: JOBID\n"
+        + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_SUCCESS = "Deleted Job: %s";
+    public static final String MESSAGE_JOB_NOT_FOUND = "This job does not exist";
+
+    private final String toDelete;
+
+    /**
+     * Creates a {@code JobDeleteCommand} to delete a {@code Job} by {@code JobId}.
+     *
+     * @param args Arguments.
+     * @throws ParseException Thrown if there is an error with parsing.
+     */
+    public JobDeleteCommand(String args) throws ParseException {
+        requireNonNull(args);
+        toDelete = new JobDeleteCommandParser().parse(args);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.hasJob(toDelete)) {
+            throw new CommandException(MESSAGE_JOB_NOT_FOUND);
+        }
+
+        try {
+            // TODO: This line breaks LoD
+            Job jobToDelete = model.getAddressBook().getJobList()
+                    .filtered(job -> job.getJobId().equals(toDelete)).get(0);
+            model.deleteJob(jobToDelete);
+        } catch (IndexOutOfBoundsException e) {
+            // Asserts that filtered list should always contain exactly the filtered element
+            assert false;
+        }
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toDelete));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof JobDeleteCommand // instanceof handles nulls
+            && toDelete.equals(((JobDeleteCommand) other).toDelete));
+    }
+}

--- a/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
@@ -2,6 +2,9 @@ package peoplesoft.logic.commands.job;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.Duration;
+import java.util.Set;
+
 import peoplesoft.logic.commands.Command;
 import peoplesoft.logic.commands.CommandResult;
 import peoplesoft.logic.commands.exceptions.CommandException;
@@ -9,6 +12,8 @@ import peoplesoft.logic.parser.exceptions.ParseException;
 import peoplesoft.logic.parser.job.JobDeleteCommandParser;
 import peoplesoft.model.Model;
 import peoplesoft.model.job.Job;
+import peoplesoft.model.job.Money;
+import peoplesoft.model.job.Rate;
 
 /**
  * Deletes a {@code Job} with a given {@code JobId}.
@@ -48,9 +53,9 @@ public class JobDeleteCommand extends Command {
         }
 
         try {
-            // TODO: This line breaks LoD
-            Job jobToDelete = model.getAddressBook().getJobList()
-                    .filtered(job -> job.getJobId().equals(toDelete)).get(0);
+            Job jobToDelete = new Job(toDelete, "empty",
+                    new Rate(new Money(1), Duration.ofHours(1)), Duration.ofHours(1), false, Set.of());
+            // Currently handles deletions in JobList implementation (by jobId)
             model.deleteJob(jobToDelete);
         } catch (IndexOutOfBoundsException e) {
             // Asserts that filtered list should always contain exactly the filtered element

--- a/src/main/java/peoplesoft/logic/commands/job/JobListCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobListCommand.java
@@ -1,0 +1,27 @@
+package peoplesoft.logic.commands.job;
+
+import static java.util.Objects.requireNonNull;
+
+import peoplesoft.logic.commands.Command;
+import peoplesoft.logic.commands.CommandResult;
+import peoplesoft.logic.commands.exceptions.CommandException;
+import peoplesoft.model.Model;
+
+/**
+ * Lists the {@code Jobs} stored in {@code AddressBook}.
+ */
+public class JobListCommand extends Command {
+
+    // TODO: change if needed
+    public static final String COMMAND_WORD = "joblist";
+
+    public static final String MESSAGE_SUCCESS = "Listed all jobs";
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        System.out.println(model.getFilteredJobList());
+        // TODO: UI interaction, currently prints to console
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/peoplesoft/logic/commands/job/JobListCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobListCommand.java
@@ -6,6 +6,7 @@ import peoplesoft.logic.commands.Command;
 import peoplesoft.logic.commands.CommandResult;
 import peoplesoft.logic.commands.exceptions.CommandException;
 import peoplesoft.model.Model;
+import peoplesoft.model.util.Employment;
 
 /**
  * Lists the {@code Jobs} stored in {@code AddressBook}.
@@ -15,13 +16,13 @@ public class JobListCommand extends Command {
     // TODO: change if needed
     public static final String COMMAND_WORD = "joblist";
 
-    public static final String MESSAGE_SUCCESS = "Listed all jobs";
+    public static final String MESSAGE_SUCCESS = "Listed all jobs: %s\nEmployment: %s";
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        System.out.println(model.getFilteredJobList());
         // TODO: UI interaction, currently prints to console
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, model.getFilteredJobList(),
+                Employment.getInstance().getAllJobs()));
     }
 }

--- a/src/main/java/peoplesoft/logic/commands/job/JobMarkCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobMarkCommand.java
@@ -1,0 +1,77 @@
+package peoplesoft.logic.commands.job;
+
+import static java.util.Objects.requireNonNull;
+
+import peoplesoft.logic.commands.Command;
+import peoplesoft.logic.commands.CommandResult;
+import peoplesoft.logic.commands.exceptions.CommandException;
+import peoplesoft.logic.parser.exceptions.ParseException;
+import peoplesoft.logic.parser.job.JobMarkCommandParser;
+import peoplesoft.model.Model;
+import peoplesoft.model.job.Job;
+
+/**
+ * Marks a {@code Job} as paid or unpaid.
+ */
+public class JobMarkCommand extends Command {
+
+    // TODO: change if needed
+    public static final String COMMAND_WORD = "mark";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Marks the job identified by the index number used in the displayed job list.\n"
+        + "Parameters: JOBID\n"
+        + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_SUCCESS = "Marked Job %s as %s";
+    public static final String MESSAGE_JOB_NOT_FOUND = "This job does not exist";
+
+    private final String toMark;
+    private boolean state;
+
+    /**
+     * Creates a {@code JobDeleteCommand} to delete a {@code Job} by {@code JobId}.
+     *
+     * @param args Arguments.
+     * @throws ParseException Thrown if there is an error with parsing.
+     */
+    public JobMarkCommand(String args) throws ParseException {
+        requireNonNull(args);
+        toMark = new JobMarkCommandParser().parse(args);
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.hasJob(toMark)) {
+            throw new CommandException(MESSAGE_JOB_NOT_FOUND);
+        }
+
+        try {
+            // TODO: This line breaks LoD
+            Job jobToMark = model.getAddressBook().getJobList()
+                .filtered(job -> job.getJobId().equals(toMark)).get(0);
+            // Creates immutable instances and replaces the existing ones
+            if (jobToMark.hasPaid()) {
+                state = true;
+                model.setJob(jobToMark, jobToMark.setAsNotPaid());
+            } else {
+                state = false;
+                model.setJob(jobToMark, jobToMark.setAsPaid());
+            }
+        } catch (IndexOutOfBoundsException e) {
+            // Asserts that filtered list should always contain exactly the filtered element
+            assert false;
+        }
+        // TODO: rudimentary result message
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toMark, state ? "not paid" : "paid"));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof JobMarkCommand // instanceof handles nulls
+            && toMark.equals(((JobMarkCommand) other).toMark));
+    }
+}

--- a/src/main/java/peoplesoft/logic/parser/AddressBookParser.java
+++ b/src/main/java/peoplesoft/logic/parser/AddressBookParser.java
@@ -15,6 +15,11 @@ import peoplesoft.logic.commands.ExitCommand;
 import peoplesoft.logic.commands.FindCommand;
 import peoplesoft.logic.commands.HelpCommand;
 import peoplesoft.logic.commands.ListCommand;
+import peoplesoft.logic.commands.job.JobAddCommand;
+import peoplesoft.logic.commands.job.JobAssignCommand;
+import peoplesoft.logic.commands.job.JobDeleteCommand;
+import peoplesoft.logic.commands.job.JobListCommand;
+import peoplesoft.logic.commands.job.JobMarkCommand;
 import peoplesoft.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +72,23 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+            // Job related commands
+
+        case JobAddCommand.COMMAND_WORD:
+            return new JobAddCommand(arguments);
+
+        case JobListCommand.COMMAND_WORD:
+            return new JobListCommand();
+
+        case JobDeleteCommand.COMMAND_WORD:
+            return new JobDeleteCommand(arguments);
+
+        case JobMarkCommand.COMMAND_WORD:
+            return new JobMarkCommand(arguments);
+
+        case JobAssignCommand.COMMAND_WORD:
+            return new JobAssignCommand(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/peoplesoft/logic/parser/CliSyntax.java
+++ b/src/main/java/peoplesoft/logic/parser/CliSyntax.java
@@ -11,5 +11,9 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_RATE = new Prefix("r/");
+    public static final Prefix PREFIX_DURATION = new Prefix("d/");
 
+    // TODO: For {@code JobAssignCommand}, change if needed
+    public static final Prefix PREFIX_INDEX = new Prefix("i/");
 }

--- a/src/main/java/peoplesoft/logic/parser/ParserUtil.java
+++ b/src/main/java/peoplesoft/logic/parser/ParserUtil.java
@@ -2,6 +2,7 @@ package peoplesoft.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -9,6 +10,8 @@ import java.util.Set;
 import peoplesoft.commons.core.index.Index;
 import peoplesoft.commons.util.StringUtil;
 import peoplesoft.logic.parser.exceptions.ParseException;
+import peoplesoft.model.job.Money;
+import peoplesoft.model.job.Rate;
 import peoplesoft.model.person.Address;
 import peoplesoft.model.person.Email;
 import peoplesoft.model.person.Name;
@@ -120,5 +123,60 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code string} is invalid.
+     */
+    public static String parseString(String str) throws ParseException {
+        requireNonNull(str);
+        String res = str.trim();
+        if (res.isBlank()) {
+            // TODO: add message
+            throw new ParseException("Empty string not allowed.");
+        }
+        return res;
+    }
+
+    /**
+     * Parses a {@code Rate}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code rate} is invalid.
+     */
+    public static Rate parseRate(String str) throws ParseException {
+        requireNonNull(str);
+        String trim = str.trim();
+        Rate res;
+        try {
+            res = new Rate(new Money(Double.parseDouble(trim)), Duration.ofHours(1));
+        } catch (NumberFormatException e) {
+            // TODO: add message/complex rate parsing %s/%s
+            throw new ParseException("Invalid value for rate");
+        }
+        return res;
+    }
+
+    /**
+     * Parses a {@code Duration}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code duration} is invalid.
+     */
+    public static Duration parseDuration(String str) throws ParseException {
+        requireNonNull(str);
+        String trim = str.trim();
+        Duration res;
+        try {
+            // TODO: Improve scuffed representation
+            res = Duration.ofSeconds((long) (Double.parseDouble(trim) * 3600));
+        } catch (NumberFormatException e) {
+            // TODO: add message
+            throw new ParseException("Invalid value for duration");
+        }
+        return res;
     }
 }

--- a/src/main/java/peoplesoft/logic/parser/job/JobAddCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobAddCommandParser.java
@@ -6,7 +6,6 @@ import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_RATE;
 
 import java.time.Duration;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import peoplesoft.commons.core.JobIdFactory;
@@ -33,17 +32,18 @@ public class JobAddCommandParser {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME,
                 PREFIX_RATE, PREFIX_DURATION);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_RATE, PREFIX_DURATION)
-            || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_RATE, PREFIX_DURATION)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     JobAddCommand.MESSAGE_USAGE));
         }
         String name = ParserUtil.parseString(argMultimap.getValue(PREFIX_NAME).get());
         Rate rate = ParserUtil.parseRate(argMultimap.getValue(PREFIX_RATE).get());
         Duration duration = ParserUtil.parseDuration(argMultimap.getValue(PREFIX_DURATION).get());
-        String id = JobIdFactory.nextId();
+        String id = !argMultimap.getPreamble().isBlank()
+                ? ParserUtil.parseString(argMultimap.getPreamble())
+                : JobIdFactory.nextId(); // Short circuit does not increment
 
-        return new Job(id, name, rate, duration, false, Set.of());
+        return new Job(id, name, rate, duration, false);
     }
 
     /**

--- a/src/main/java/peoplesoft/logic/parser/job/JobAddCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobAddCommandParser.java
@@ -1,0 +1,56 @@
+package peoplesoft.logic.parser.job;
+
+import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_DURATION;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_RATE;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import peoplesoft.commons.core.JobIdFactory;
+import peoplesoft.logic.commands.job.JobAddCommand;
+import peoplesoft.logic.parser.ArgumentMultimap;
+import peoplesoft.logic.parser.ArgumentTokenizer;
+import peoplesoft.logic.parser.ParserUtil;
+import peoplesoft.logic.parser.Prefix;
+import peoplesoft.logic.parser.exceptions.ParseException;
+import peoplesoft.model.job.Job;
+import peoplesoft.model.job.Rate;
+
+/**
+ * Parses input parameters and returns a {@code Job}.
+ */
+public class JobAddCommandParser {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code JobAddCommand}
+     * and returns a {@code Job} object for {@code JobAddCommand}.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public Job parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME,
+                PREFIX_RATE, PREFIX_DURATION);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_RATE, PREFIX_DURATION)
+            || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    JobAddCommand.MESSAGE_USAGE));
+        }
+        String name = ParserUtil.parseString(argMultimap.getValue(PREFIX_NAME).get());
+        Rate rate = ParserUtil.parseRate(argMultimap.getValue(PREFIX_RATE).get());
+        Duration duration = ParserUtil.parseDuration(argMultimap.getValue(PREFIX_DURATION).get());
+        String id = JobIdFactory.nextId();
+
+        return new Job(id, name, rate, duration, false, Set.of());
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/peoplesoft/logic/parser/job/JobAssignCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobAssignCommandParser.java
@@ -1,0 +1,43 @@
+package peoplesoft.logic.parser.job;
+
+import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_INDEX;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.stream.Stream;
+
+import peoplesoft.logic.commands.job.JobAssignCommand;
+import peoplesoft.logic.parser.ArgumentMultimap;
+import peoplesoft.logic.parser.ArgumentTokenizer;
+import peoplesoft.logic.parser.Prefix;
+import peoplesoft.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses a {@code jobId} and an {@code index} for {@code Person}.
+ */
+public class JobAssignCommandParser {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code JobAssignCommand}
+     * and returns an {@code ArgumentMultimap} for {@code JobAssignCommand}.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ArgumentMultimap parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME,
+            PREFIX_INDEX);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_INDEX)
+            || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                JobAssignCommand.MESSAGE_USAGE));
+        }
+        return argMultimap;
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/peoplesoft/logic/parser/job/JobAssignCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobAssignCommandParser.java
@@ -2,7 +2,6 @@ package peoplesoft.logic.parser.job;
 
 import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_INDEX;
-import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.stream.Stream;
 
@@ -22,11 +21,10 @@ public class JobAssignCommandParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ArgumentMultimap parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME,
-            PREFIX_INDEX);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_INDEX)
-            || !argMultimap.getPreamble().isEmpty()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_INDEX)
+            || argMultimap.getPreamble().isBlank()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 JobAssignCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/peoplesoft/logic/parser/job/JobDeleteCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobDeleteCommandParser.java
@@ -1,0 +1,26 @@
+package peoplesoft.logic.parser.job;
+
+import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import peoplesoft.logic.commands.job.JobDeleteCommand;
+import peoplesoft.logic.parser.ParserUtil;
+import peoplesoft.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses a {@code jobId} to delete.
+ */
+public class JobDeleteCommandParser {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code JobDeleteCommand}
+     * and returns a {@code JobId} string for {@code JobDeleteCommand}.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public String parse(String args) throws ParseException {
+        try {
+            return ParserUtil.parseString(args);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, JobDeleteCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/peoplesoft/logic/parser/job/JobMarkCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobMarkCommandParser.java
@@ -1,0 +1,26 @@
+package peoplesoft.logic.parser.job;
+
+import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import peoplesoft.logic.commands.job.JobMarkCommand;
+import peoplesoft.logic.parser.ParserUtil;
+import peoplesoft.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses a {@code JobId} to mark.
+ */
+public class JobMarkCommandParser {
+    /**
+     * Parses the given {@code String} of arguments in the context of the {@code JobMarkCommand}
+     * and returns a {@code JobId} string for {@code JobMarkCommand}.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public String parse(String args) throws ParseException {
+        try {
+            return ParserUtil.parseString(args);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, JobMarkCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/main/java/peoplesoft/model/AddressBook.java
+++ b/src/main/java/peoplesoft/model/AddressBook.java
@@ -136,9 +136,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     /**
      * Returns true if a job with the same identity as {@code job} exists in the address book.
      */
-    public boolean hasJob(Job job) {
-        requireNonNull(job);
-        return jobs.contains(job);
+    public boolean hasJob(String jobId) {
+        requireNonNull(jobId);
+        return jobs.contains(jobId);
     }
 
     /**

--- a/src/main/java/peoplesoft/model/Model.java
+++ b/src/main/java/peoplesoft/model/Model.java
@@ -92,7 +92,7 @@ public interface Model {
     /**
      * Returns true if a job with the same job id as {@code job} exists in the address book.
      */
-    boolean hasJob(Job job);
+    boolean hasJob(String jobId);
 
     /**
      * Deletes the given job.

--- a/src/main/java/peoplesoft/model/Model.java
+++ b/src/main/java/peoplesoft/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import peoplesoft.commons.core.GuiSettings;
+import peoplesoft.model.job.Job;
 import peoplesoft.model.person.Person;
 
 /**
@@ -13,6 +14,9 @@ import peoplesoft.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Job> PREDICATE_SHOW_ALL_JOBS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -84,4 +88,37 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Returns true if a job with the same job id as {@code job} exists in the address book.
+     */
+    boolean hasJob(Job job);
+
+    /**
+     * Deletes the given job.
+     * The job must exist in the address book.
+     */
+    void deleteJob(Job target);
+
+    /**
+     * Adds the given job.
+     * {@code job} must not already exist in the address book.
+     */
+    void addJob(Job job);
+
+    /**
+     * Replaces the given job {@code target} with {@code editedJob}.
+     * {@code target} must exist in the address book.
+     * The job identity of {@code editedJob} must not be the same as another existing job in the address book.
+     */
+    void setJob(Job target, Job editedJob);
+
+    /** Returns an unmodifiable view of the filtered job list */
+    ObservableList<Job> getFilteredJobList();
+
+    /**
+     * Updates the filter of the filtered job list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void updateFilteredJobList(Predicate<Job> predicate);
 }

--- a/src/main/java/peoplesoft/model/ModelManager.java
+++ b/src/main/java/peoplesoft/model/ModelManager.java
@@ -135,9 +135,9 @@ public class ModelManager implements Model {
     //=========== Job Operations =============================================================================
 
     @Override
-    public boolean hasJob(Job job) {
-        requireNonNull(job);
-        return addressBook.hasJob(job);
+    public boolean hasJob(String jobId) {
+        requireNonNull(jobId);
+        return addressBook.hasJob(jobId);
     }
 
     @Override

--- a/src/main/java/peoplesoft/model/ModelManager.java
+++ b/src/main/java/peoplesoft/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import peoplesoft.commons.core.GuiSettings;
 import peoplesoft.commons.core.LogsCenter;
+import peoplesoft.model.job.Job;
 import peoplesoft.model.person.Person;
 
 /**
@@ -22,6 +23,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final FilteredList<Job> filteredJobs;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -34,6 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredJobs = new FilteredList<>(this.addressBook.getJobList());
     }
 
     public ModelManager() {
@@ -87,6 +90,8 @@ public class ModelManager implements Model {
         return addressBook;
     }
 
+    //=========== Person Operations ==========================================================================
+
     @Override
     public boolean hasPerson(Person person) {
         requireNonNull(person);
@@ -107,7 +112,6 @@ public class ModelManager implements Model {
     @Override
     public void setPerson(Person target, Person editedPerson) {
         requireAllNonNull(target, editedPerson);
-
         addressBook.setPerson(target, editedPerson);
     }
 
@@ -128,6 +132,48 @@ public class ModelManager implements Model {
         filteredPersons.setPredicate(predicate);
     }
 
+    //=========== Job Operations =============================================================================
+
+    @Override
+    public boolean hasJob(Job job) {
+        requireNonNull(job);
+        return addressBook.hasJob(job);
+    }
+
+    @Override
+    public void deleteJob(Job target) {
+        addressBook.removeJob(target);
+    }
+
+    @Override
+    public void addJob(Job job) {
+        addressBook.addJob(job);
+        updateFilteredJobList(PREDICATE_SHOW_ALL_JOBS);
+    }
+
+    @Override
+    public void setJob(Job target, Job editedJob) {
+        requireAllNonNull(target, editedJob);
+        addressBook.setJob(target, editedJob);
+    }
+
+    //=========== Filtered Job List Accessors ================================================================
+
+    /**
+     * Returns an unmodifiable view of the list of {@code Job} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    @Override
+    public ObservableList<Job> getFilteredJobList() {
+        return filteredJobs;
+    }
+
+    @Override
+    public void updateFilteredJobList(Predicate<Job> predicate) {
+        requireNonNull(predicate);
+        filteredJobs.setPredicate(predicate);
+    }
+
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object
@@ -144,7 +190,7 @@ public class ModelManager implements Model {
         ModelManager other = (ModelManager) obj;
         return addressBook.equals(other.addressBook)
                 && userPrefs.equals(other.userPrefs)
-                && filteredPersons.equals(other.filteredPersons);
+                && filteredPersons.equals(other.filteredPersons)
+                && filteredJobs.equals(other.filteredJobs);
     }
-
 }

--- a/src/main/java/peoplesoft/model/ReadOnlyAddressBook.java
+++ b/src/main/java/peoplesoft/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package peoplesoft.model;
 
 import javafx.collections.ObservableList;
+import peoplesoft.model.job.Job;
 import peoplesoft.model.person.Person;
 
 /**
@@ -14,4 +15,9 @@ public interface ReadOnlyAddressBook {
      */
     ObservableList<Person> getPersonList();
 
+    /**
+     * Returns an unmodifiable view of the jobs list.
+     * This list will not contain any duplicate jobs.
+     */
+    ObservableList<Job> getJobList();
 }

--- a/src/main/java/peoplesoft/model/job/Job.java
+++ b/src/main/java/peoplesoft/model/job/Job.java
@@ -135,6 +135,16 @@ public class Job {
 
     @Override
     public String toString() {
-        return super.toString();
+        final StringBuilder builder = new StringBuilder();
+        builder.append(getJobId())
+            .append("; Name: ")
+            .append(getDesc())
+            .append("; Rate: ")
+            .append(getRate())
+            .append("; Duration: ")
+            .append(getDuration().toHours())
+            .append("H");
+
+        return builder.toString();
     }
 }

--- a/src/main/java/peoplesoft/model/job/Job.java
+++ b/src/main/java/peoplesoft/model/job/Job.java
@@ -2,17 +2,31 @@ package peoplesoft.model.job;
 
 import static peoplesoft.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.io.IOException;
 import java.time.Duration;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
 
-import peoplesoft.model.person.Person;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import peoplesoft.commons.util.JsonUtil;
 
 /**
  * Represents a job. Immutable.
  */
+@JsonSerialize(using = Job.JobSerializer.class)
+@JsonDeserialize(using = Job.JobDeserializer.class)
 public class Job {
 
     private final String jobId;
@@ -22,20 +36,17 @@ public class Job {
 
     private final boolean hasPaid;
 
-    private final Set<Person> persons = new HashSet<>();
-
     /**
      * Constructor for an immutable job.
      * All fields must not be null.
      */
-    public Job(String jobId, String desc, Rate rate, Duration duration, boolean hasPaid, Set<Person> persons) {
-        requireAllNonNull(jobId, desc, rate, duration, hasPaid, persons);
+    public Job(String jobId, String desc, Rate rate, Duration duration, boolean hasPaid) {
+        requireAllNonNull(jobId, desc, rate, duration, hasPaid);
         this.jobId = jobId;
         this.desc = desc;
         this.rate = rate;
         this.duration = duration;
         this.hasPaid = hasPaid;
-        this.persons.addAll(persons);
     }
 
     public String getJobId() {
@@ -59,15 +70,6 @@ public class Job {
     }
 
     /**
-     * Returns an immutable person set.
-     *
-     * @return Immutable set of persons.
-     */
-    public Set<Person> getPersons() {
-        return Collections.unmodifiableSet(persons);
-    }
-
-    /**
      * Returns the pay of the job.
      * Calculated from rate and duration.
      *
@@ -83,7 +85,7 @@ public class Job {
      * @return Paid job.
      */
     public Job setAsPaid() {
-        return new Job(jobId, desc, rate, duration, true, persons);
+        return new Job(jobId, desc, rate, duration, true);
     }
 
     /**
@@ -92,7 +94,7 @@ public class Job {
      * @return Unpaid job.
      */
     public Job setAsNotPaid() {
-        return new Job(jobId, desc, rate, duration, false, persons);
+        return new Job(jobId, desc, rate, duration, false);
     }
 
     /**
@@ -124,27 +126,110 @@ public class Job {
                 && otherJob.getDesc().equals(getDesc())
                 && otherJob.getRate().equals(getRate())
                 && otherJob.getDuration().equals(getDuration())
-                && otherJob.hasPaid() == hasPaid()
-                && otherJob.getPersons().equals(getPersons());
+                && otherJob.hasPaid() == hasPaid();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(jobId, desc, rate, duration, hasPaid, persons);
+        return Objects.hash(jobId, desc, rate, duration, hasPaid);
     }
 
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();
-        builder.append(getJobId())
+        builder.append("ID: ")
+            .append(getJobId())
             .append("; Name: ")
             .append(getDesc())
             .append("; Rate: ")
             .append(getRate())
             .append("; Duration: ")
-            .append(getDuration().toHours())
-            .append("H");
+            .append(getDuration().toHoursPart())
+            .append("H")
+            .append(getDuration().toMinutesPart())
+            .append("M")
+            .append("; Has paid: ")
+            .append(hasPaid());
 
         return builder.toString();
+    }
+
+    protected static class JobSerializer extends StdSerializer<Job> {
+        private JobSerializer(Class<Job> val) {
+            super(val);
+        }
+
+        private JobSerializer() {
+            this(null);
+        }
+
+        @Override
+        public void serialize(Job value, JsonGenerator gen, SerializerProvider provider)throws IOException {
+            gen.writeStartObject();
+
+            gen.writeStringField("jobId", value.getJobId());
+            gen.writeStringField("desc", value.getDesc());
+            gen.writeObjectField("rate", value.getRate());
+            gen.writeObjectField("duration", value.getDuration());
+            gen.writeBooleanField("hasPaid", value.hasPaid());
+
+            gen.writeEndObject();
+        }
+    }
+
+    protected static class JobDeserializer extends StdDeserializer<Job> {
+        private static final String MISSING_OR_INVALID_INSTANCE = "The job instance is invalid or missing!";
+        private static final String MISSING_OR_INVALID_VALUE = "The job's %s field is invalid or missing!";
+
+        private JobDeserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        private JobDeserializer() {
+            this(null);
+        }
+
+        private static JsonNode getNonNullNode(ObjectNode node, String key, DeserializationContext ctx)
+            throws JsonMappingException {
+            JsonNode jsonNode = node.get(key);
+            if (jsonNode == null) {
+                throw JsonUtil.getWrappedIllegalValueException(
+                    ctx, String.format(MISSING_OR_INVALID_VALUE, key));
+            }
+
+            return jsonNode;
+        }
+
+        @Override
+        public Job deserialize(JsonParser p, DeserializationContext ctx)
+                throws IOException, JsonProcessingException {
+            JsonNode node = p.readValueAsTree();
+            ObjectCodec codec = p.getCodec();
+
+            if (!(node instanceof ObjectNode)) {
+                throw JsonUtil.getWrappedIllegalValueException(ctx, MISSING_OR_INVALID_INSTANCE);
+            }
+
+            ObjectNode job = (ObjectNode) node;
+
+            String jobId = getNonNullNode(job, "jobId", ctx).textValue();
+
+            String desc = getNonNullNode(job, "desc", ctx).textValue();
+
+            Rate rate = codec.treeToValue(
+                    getNonNullNode(job, "rate", ctx), Rate.class);
+
+            Duration duration = codec.treeToValue(
+                    getNonNullNode(job, "duration", ctx), Duration.class);
+
+            Boolean hasPaid = getNonNullNode(job, "hasPaid", ctx).booleanValue();
+
+            return new Job(jobId, desc, rate, duration, hasPaid);
+        }
+
+        @Override
+        public Job getNullValue(DeserializationContext ctx) throws JsonMappingException {
+            throw JsonUtil.getWrappedIllegalValueException(ctx, MISSING_OR_INVALID_INSTANCE);
+        }
     }
 }

--- a/src/main/java/peoplesoft/model/job/JobList.java
+++ b/src/main/java/peoplesoft/model/job/JobList.java
@@ -6,7 +6,10 @@ import javafx.collections.ObservableList;
 
 public interface JobList extends Iterable<Job> {
 
-    boolean contains(Job toCheck);
+    // TODO: should jobs compare by jobs or jobId, since add it seems more intuitive
+    // to compare by jobs but delete seems more intuitive to compare by jobId.
+    // For now it is jobId.
+    boolean contains(String jobId);
 
     void add(Job toAdd);
 

--- a/src/main/java/peoplesoft/model/job/JobListManager.java
+++ b/src/main/java/peoplesoft/model/job/JobListManager.java
@@ -38,9 +38,10 @@ public class JobListManager implements JobList {
     @Override
     public void remove(Job toRemove) {
         requireNonNull(toRemove);
-        if (!internalList.remove(toRemove)) {
+        if (!contains(toRemove.getJobId())) {
             throw new JobNotFoundException();
         }
+        internalList.removeIf(job -> job.isSameJob(toRemove));
     }
 
     @Override

--- a/src/main/java/peoplesoft/model/job/JobListManager.java
+++ b/src/main/java/peoplesoft/model/job/JobListManager.java
@@ -11,7 +11,9 @@ import javafx.collections.ObservableList;
 import peoplesoft.model.job.exceptions.DuplicateJobException;
 import peoplesoft.model.job.exceptions.JobNotFoundException;
 
-
+/**
+ * Implementation of {@code JobList}.
+ */
 public class JobListManager implements JobList {
 
     private final ObservableList<Job> internalList = FXCollections.observableArrayList();
@@ -19,15 +21,15 @@ public class JobListManager implements JobList {
             FXCollections.unmodifiableObservableList(internalList);
 
     @Override
-    public boolean contains(Job toCheck) {
-        requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::equals);
+    public boolean contains(String jobId) {
+        requireNonNull(jobId);
+        return internalList.stream().anyMatch(job -> job.getJobId().equals(jobId));
     }
 
     @Override
     public void add(Job toAdd) {
         requireNonNull(toAdd);
-        if (contains(toAdd)) {
+        if (contains(toAdd.getJobId())) {
             throw new DuplicateJobException();
         }
         internalList.add(toAdd);
@@ -50,7 +52,7 @@ public class JobListManager implements JobList {
             throw new JobNotFoundException();
         }
 
-        if (!targetJob.equals(editedJob) && contains(editedJob)) {
+        if (!targetJob.isSameJob(editedJob) && contains(editedJob.getJobId())) {
             throw new DuplicateJobException();
         }
 

--- a/src/main/java/peoplesoft/model/job/Rate.java
+++ b/src/main/java/peoplesoft/model/job/Rate.java
@@ -37,7 +37,7 @@ public class Rate {
     /**
      * Constructs a {@code Rate} instance.
      *
-     * @param value A value as a double.
+     * @param amount A value as a double.
      */
     public Rate(Money amount, Duration duration) {
         requireAllNonNull(amount, duration);
@@ -96,7 +96,7 @@ public class Rate {
     @Override
     public String toString() {
         // TODO make it more user friendly, e.g. $5 / hour
-        return String.format("%s / %s", amount, duration);
+        return String.format("%s / %dH", amount, duration.toHours());
     }
 
     protected static class RateSerializer extends StdSerializer<Rate> {

--- a/src/main/java/peoplesoft/model/util/Employment.java
+++ b/src/main/java/peoplesoft/model/util/Employment.java
@@ -2,9 +2,26 @@ package peoplesoft.model.util;
 
 import static peoplesoft.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import peoplesoft.commons.util.JsonUtil;
 import peoplesoft.model.Model;
 import peoplesoft.model.job.Job;
 import peoplesoft.model.person.Name;
@@ -13,14 +30,31 @@ import peoplesoft.model.person.Person;
 /**
  * Association class to handle assigning {@code Jobs} to {@code Persons}.
  */
-// TODO: Refactor class name/package if necessary
+@JsonSerialize(using = Employment.EmploymentSerializer.class)
+@JsonDeserialize(using = Employment.EmploymentDeserializer.class)
 public class Employment {
+    // TODO: Refactor class name/package if necessary
     // TODO: Feel free to change implementation
-    // Made it a singleton because did not know where to put it.
+    /**
+     * Singleton instance.
+     */
+    private static Employment instance;
+
     /**
      * Maps {@code JobId} to {@code Name}.
      */
-    private static HashMap<String, Name> map = new HashMap<>();
+    private HashMap<String, Name> map;
+
+    /**
+     * Constructor for {@code getInstance}.
+     */
+    private Employment() {
+        map = new HashMap<>();
+    }
+
+    public Employment(HashMap<String, Name> map) {
+        this.map = map;
+    }
 
     /**
      * Adds an association of a {@code Job} with a {@code Person}.
@@ -30,10 +64,41 @@ public class Employment {
      */
     // TODO: There is an issue where if a person gets edited/deleted, the
     // association would not update. Also currently does not handle serdes.
-    public static void associate(Job job, Person person) {
+    public void associate(Job job, Person person) {
         requireAllNonNull(job, person);
         // The nature of put assigns 1 job to 1 person
         map.put(job.getJobId(), person.getName());
+    }
+
+    /**
+     * Deletes all entries of a {@code Person}.
+     *
+     * @param person {@code Person} to delete.
+     */
+    public void deletePerson(Person person) {
+        requireAllNonNull(person);
+        map.entrySet().removeIf(entry -> entry.getValue().equals(person.getName()));
+    }
+
+    /**
+     * Edits all entries of a {@code Person}.
+     *
+     * @param toEdit {@code Person} to edit.
+     * @param editedPerson {@code Person} that replaces.
+     */
+    public void editPerson(Person toEdit, Person editedPerson) {
+        requireAllNonNull(toEdit, editedPerson);
+        map.replaceAll((jobId, name) -> name.equals(toEdit.getName()) ? editedPerson.getName() : name);
+    }
+
+    /**
+     * Deletes the entry of a {@code Job}.
+     *
+     * @param job {@code Job} to delete.
+     */
+    public void deleteJob(Job job) {
+        requireAllNonNull(job);
+        map.remove(job.getJobId());
     }
 
     /**
@@ -43,10 +108,99 @@ public class Employment {
      * @param model Model.
      * @return List of jobs.
      */
-    public static List<Job> getJobs(Person person, Model model) {
+    public List<Job> getJobs(Person person, Model model) {
         requireAllNonNull(person, model);
         // TODO: Scuffed but workable, change if needed.
-        model.updateFilteredJobList(job -> map.get(job.getJobId()).equals(person.getName()));
+        model.updateFilteredJobList(job -> person.getName().equals(map.get(job.getJobId())));
         return model.getFilteredJobList();
+    }
+
+    /**
+     * Returns a list of {@code Jobs} that a {@code Person} has.
+     *
+     * @return Map of jobs.
+     */
+    public HashMap<String, Name> getAllJobs() {
+        return map;
+    }
+
+    /**
+     * Sets the singleton instance of {@code Employment}.
+     *
+     * @param employment Instance to set.
+     */
+    public static void setInstance(Employment employment) {
+        instance = employment;
+    }
+
+    /**
+     * Creates a new singleton instance of {@code Employment}.
+     *
+     */
+    public static void newInstance() {
+        instance = new Employment();
+    }
+
+    /**
+     * Returns the instance of {@code Employment}.
+     *
+     * @return {@code Employment} instance.
+     */
+    public static Employment getInstance() {
+        if (instance == null) {
+            instance = new Employment();
+        }
+        return instance;
+    }
+
+    protected static class EmploymentSerializer extends StdSerializer<Employment> {
+        private EmploymentSerializer(Class<Employment> val) {
+            super(val);
+        }
+
+        private EmploymentSerializer() {
+            this(null);
+        }
+
+        @Override
+        public void serialize(Employment value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            gen.writeObject(value.map);
+        }
+    }
+
+    protected static class EmploymentDeserializer extends StdDeserializer<Employment> {
+        private static final String MISSING_OR_INVALID_VALUE = "Invalid employment!";
+
+        private EmploymentDeserializer(Class<?> vc) {
+            super(vc);
+        }
+
+        private EmploymentDeserializer() {
+            this(null);
+        }
+
+        @Override
+        public Employment deserialize(JsonParser p, DeserializationContext ctx)
+                throws IOException, JsonProcessingException {
+            JsonNode node = p.readValueAsTree();
+            ObjectCodec codec = p.getCodec();
+
+            if (!(node instanceof ObjectNode)) {
+                throw JsonUtil.getWrappedIllegalValueException(ctx, MISSING_OR_INVALID_VALUE);
+            }
+
+            JsonParser mapParser = node.traverse(codec);
+            HashMap<String, Name> map = codec.readValue(mapParser,
+                    new TypeReference<HashMap<String, Name>>(){});
+
+            System.out.println(map);
+
+            return new Employment(map);
+        }
+
+        @Override
+        public Employment getNullValue(DeserializationContext ctx) throws JsonMappingException {
+            throw JsonUtil.getWrappedIllegalValueException(ctx, MISSING_OR_INVALID_VALUE);
+        }
     }
 }

--- a/src/main/java/peoplesoft/model/util/Employment.java
+++ b/src/main/java/peoplesoft/model/util/Employment.java
@@ -1,0 +1,52 @@
+package peoplesoft.model.util;
+
+import static peoplesoft.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.HashMap;
+import java.util.List;
+
+import peoplesoft.model.Model;
+import peoplesoft.model.job.Job;
+import peoplesoft.model.person.Name;
+import peoplesoft.model.person.Person;
+
+/**
+ * Association class to handle assigning {@code Jobs} to {@code Persons}.
+ */
+// TODO: Refactor class name/package if necessary
+public class Employment {
+    // TODO: Feel free to change implementation
+    // Made it a singleton because did not know where to put it.
+    /**
+     * Maps {@code JobId} to {@code Name}.
+     */
+    private static HashMap<String, Name> map = new HashMap<>();
+
+    /**
+     * Adds an association of a {@code Job} with a {@code Person}.
+     *
+     * @param job Job.
+     * @param person Person.
+     */
+    // TODO: There is an issue where if a person gets edited/deleted, the
+    // association would not update. Also currently does not handle serdes.
+    public static void associate(Job job, Person person) {
+        requireAllNonNull(job, person);
+        // The nature of put assigns 1 job to 1 person
+        map.put(job.getJobId(), person.getName());
+    }
+
+    /**
+     * Returns a list of {@code Jobs} that a {@code Person} has.
+     *
+     * @param person Person.
+     * @param model Model.
+     * @return List of jobs.
+     */
+    public static List<Job> getJobs(Person person, Model model) {
+        requireAllNonNull(person, model);
+        // TODO: Scuffed but workable, change if needed.
+        model.updateFilteredJobList(job -> map.get(job.getJobId()).equals(person.getName()));
+        return model.getFilteredJobList();
+    }
+}

--- a/src/test/java/peoplesoft/logic/commands/AddCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/AddCommandTest.java
@@ -6,21 +6,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static peoplesoft.testutil.Assert.assertThrows;
 
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import peoplesoft.commons.core.GuiSettings;
 import peoplesoft.logic.commands.exceptions.CommandException;
 import peoplesoft.model.AddressBook;
-import peoplesoft.model.Model;
 import peoplesoft.model.ReadOnlyAddressBook;
-import peoplesoft.model.ReadOnlyUserPrefs;
-import peoplesoft.model.job.Job;
 import peoplesoft.model.person.Person;
 import peoplesoft.testutil.PersonBuilder;
 
@@ -73,111 +66,6 @@ public class AddCommandTest {
 
         // different person -> returns false
         assertFalse(addAliceCommand.equals(addBobCommand));
-    }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasJob(String jobId) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deleteJob(Job target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addJob(Job job) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setJob(Job target, Job editedJob) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Job> getFilteredJobList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredJobList(Predicate<Job> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
     }
 
     /**

--- a/src/test/java/peoplesoft/logic/commands/AddCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/AddCommandTest.java
@@ -150,7 +150,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean hasJob(Job job) {
+        public boolean hasJob(String jobId) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/peoplesoft/logic/commands/AddCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/AddCommandTest.java
@@ -20,6 +20,7 @@ import peoplesoft.model.AddressBook;
 import peoplesoft.model.Model;
 import peoplesoft.model.ReadOnlyAddressBook;
 import peoplesoft.model.ReadOnlyUserPrefs;
+import peoplesoft.model.job.Job;
 import peoplesoft.model.person.Person;
 import peoplesoft.testutil.PersonBuilder;
 
@@ -145,6 +146,36 @@ public class AddCommandTest {
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasJob(Job job) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deleteJob(Job target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addJob(Job job) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setJob(Job target, Job editedJob) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Job> getFilteredJobList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredJobList(Predicate<Job> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/peoplesoft/logic/commands/ModelStub.java
+++ b/src/test/java/peoplesoft/logic/commands/ModelStub.java
@@ -1,0 +1,117 @@
+package peoplesoft.logic.commands;
+
+import java.nio.file.Path;
+import java.util.function.Predicate;
+
+import javafx.collections.ObservableList;
+import peoplesoft.commons.core.GuiSettings;
+import peoplesoft.model.Model;
+import peoplesoft.model.ReadOnlyAddressBook;
+import peoplesoft.model.ReadOnlyUserPrefs;
+import peoplesoft.model.job.Job;
+import peoplesoft.model.person.Person;
+
+/**
+ * A default model stub that have all of the methods failing.
+ */
+public class ModelStub implements Model {
+    @Override
+    public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyUserPrefs getUserPrefs() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public GuiSettings getGuiSettings() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setGuiSettings(GuiSettings guiSettings) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public Path getAddressBookFilePath() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBookFilePath(Path addressBookFilePath) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setAddressBook(ReadOnlyAddressBook newData) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ReadOnlyAddressBook getAddressBook() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasPerson(Person person) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deletePerson(Person target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setPerson(Person target, Person editedPerson) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Person> getFilteredPersonList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredPersonList(Predicate<Person> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public boolean hasJob(String jobId) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void deleteJob(Job target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void addJob(Job job) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void setJob(Job target, Job editedJob) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public ObservableList<Job> getFilteredJobList() {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
+    public void updateFilteredJobList(Predicate<Job> predicate) {
+        throw new AssertionError("This method should not be called.");
+    }
+}

--- a/src/test/java/peoplesoft/logic/commands/job/JobAddCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobAddCommandTest.java
@@ -1,0 +1,23 @@
+package peoplesoft.logic.commands.job;
+
+import static peoplesoft.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class JobAddCommandTest {
+
+    private static final String CORRECT_ARGS = " n/name r/1.0 d/3";
+
+    @Test
+    public void constructor_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new JobAddCommand(null));
+    }
+
+    @Test
+    public void execute_nullModel_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new JobAddCommand(CORRECT_ARGS).execute(null));
+    }
+
+    // TODO: Add model stubs to test command.
+    // Perhaps a common model stub class can be made.
+}

--- a/src/test/java/peoplesoft/logic/commands/job/JobAssignCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobAssignCommandTest.java
@@ -32,7 +32,7 @@ public class JobAssignCommandTest {
     @Test
     public void constructor_wrongFormatArgs_throwsParseException() {
         // Empty name
-        assertThrows(ParseException.class, () -> new JobAssignCommand("n/ i/1"));
+        assertThrows(ParseException.class, () -> new JobAssignCommand(" i/1"));
         // Incorrect index parse
         assertThrows(ParseException.class, () -> new JobAssignCommand("n/correct i/0"));
     }

--- a/src/test/java/peoplesoft/logic/commands/job/JobAssignCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobAssignCommandTest.java
@@ -1,0 +1,39 @@
+package peoplesoft.logic.commands.job;
+
+import static peoplesoft.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import peoplesoft.logic.parser.exceptions.ParseException;
+
+public class JobAssignCommandTest {
+
+    private static final String CORRECT_ARGS = " n/correct i/1";
+
+    @Test
+    public void constructor_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new JobAssignCommand(null));
+    }
+
+    @Test
+    public void execute_nullModel_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new JobAssignCommand(CORRECT_ARGS).execute(null));
+    }
+
+    @Test
+    public void execute_incorrectArgs_throwsCommandException() {
+        // TODO
+    }
+
+    // TODO: Add model stubs to test command.
+    // Perhaps a common model stub class can be made.
+
+    // TODO: May shift to parser depending on implementation
+    @Test
+    public void constructor_wrongFormatArgs_throwsParseException() {
+        // Empty name
+        assertThrows(ParseException.class, () -> new JobAssignCommand("n/ i/1"));
+        // Incorrect index parse
+        assertThrows(ParseException.class, () -> new JobAssignCommand("n/correct i/0"));
+    }
+}

--- a/src/test/java/peoplesoft/logic/commands/job/JobDeleteCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobDeleteCommandTest.java
@@ -1,13 +1,30 @@
 package peoplesoft.logic.commands.job;
 
+import static peoplesoft.logic.commands.CommandTestUtil.assertCommandFailure;
+import static peoplesoft.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static peoplesoft.testutil.Assert.assertThrows;
+import static peoplesoft.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.time.Duration;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
+
+import peoplesoft.model.Model;
+import peoplesoft.model.ModelManager;
+import peoplesoft.model.UserPrefs;
+import peoplesoft.model.job.Job;
+import peoplesoft.model.job.Money;
+import peoplesoft.model.job.Rate;
 
 public class JobDeleteCommandTest {
 
     private static final String CORRECT_ARGS = "correct";
     private static final String INCORRECT_ARGS = "incorrect";
+
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Job job = new Job(CORRECT_ARGS, "The Right Job",
+            new Rate(new Money(1), Duration.ofHours(1)), Duration.ofHours(2), false, Set.of());
 
     @Test
     public void constructor_nullArgs_throwsNullPointerException() {
@@ -20,8 +37,17 @@ public class JobDeleteCommandTest {
     }
 
     @Test
-    public void execute_incorrectArgs_throwsCommandException() {
-        // TODO
+    public void execute_incorrectArgs_throwsCommandException() throws Exception {
+        JobDeleteCommand cmd = new JobDeleteCommand(INCORRECT_ARGS);
+        assertCommandFailure(cmd, expectedModel, JobDeleteCommand.MESSAGE_JOB_NOT_FOUND);
     }
-    // TODO: Model stub
+
+    @Test
+    public void execute_correctArgs_success() throws Exception {
+        Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        model.addJob(job);
+        JobDeleteCommand cmd = new JobDeleteCommand(CORRECT_ARGS);
+        assertCommandSuccess(cmd, model, String.format(JobDeleteCommand.MESSAGE_SUCCESS, job.getJobId()),
+                expectedModel);
+    }
 }

--- a/src/test/java/peoplesoft/logic/commands/job/JobDeleteCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobDeleteCommandTest.java
@@ -1,0 +1,27 @@
+package peoplesoft.logic.commands.job;
+
+import static peoplesoft.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class JobDeleteCommandTest {
+
+    private static final String CORRECT_ARGS = "correct";
+    private static final String INCORRECT_ARGS = "incorrect";
+
+    @Test
+    public void constructor_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new JobDeleteCommand(null));
+    }
+
+    @Test
+    public void execute_nullModel_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new JobDeleteCommand(CORRECT_ARGS).execute(null));
+    }
+
+    @Test
+    public void execute_incorrectArgs_throwsCommandException() {
+        // TODO
+    }
+    // TODO: Model stub
+}

--- a/src/test/java/peoplesoft/logic/commands/job/JobDeleteCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobDeleteCommandTest.java
@@ -6,7 +6,6 @@ import static peoplesoft.testutil.Assert.assertThrows;
 import static peoplesoft.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.time.Duration;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +23,7 @@ public class JobDeleteCommandTest {
 
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Job job = new Job(CORRECT_ARGS, "The Right Job",
-            new Rate(new Money(1), Duration.ofHours(1)), Duration.ofHours(2), false, Set.of());
+            new Rate(new Money(1), Duration.ofHours(1)), Duration.ofHours(2), false);
 
     @Test
     public void constructor_nullArgs_throwsNullPointerException() {

--- a/src/test/java/peoplesoft/logic/commands/job/JobMarkCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobMarkCommandTest.java
@@ -1,0 +1,27 @@
+package peoplesoft.logic.commands.job;
+
+import static peoplesoft.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class JobMarkCommandTest {
+
+    private static final String CORRECT_ARGS = "correct";
+    private static final String INCORRECT_ARGS = "incorrect";
+
+    @Test
+    public void constructor_nullArgs_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new JobMarkCommand(null));
+    }
+
+    @Test
+    public void execute_nullModel_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new JobMarkCommand(CORRECT_ARGS).execute(null));
+    }
+
+    @Test
+    public void execute_incorrectArgs_throwsCommandException() {
+        // TODO
+    }
+    // TODO: Model stub
+}

--- a/src/test/java/peoplesoft/logic/parser/ParserUtilTest.java
+++ b/src/test/java/peoplesoft/logic/parser/ParserUtilTest.java
@@ -6,6 +6,7 @@ import static peoplesoft.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static peoplesoft.testutil.Assert.assertThrows;
 import static peoplesoft.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -14,6 +15,8 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 import peoplesoft.logic.parser.exceptions.ParseException;
+import peoplesoft.model.job.Money;
+import peoplesoft.model.job.Rate;
 import peoplesoft.model.person.Address;
 import peoplesoft.model.person.Email;
 import peoplesoft.model.person.Name;
@@ -26,6 +29,8 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
+    private static final String INVALID_RATE = "hello";
+    private static final String INVALID_DURATION = "world";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -33,6 +38,9 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_STRING = "hello";
+    private static final String VALID_RATE = "3.0";
+    private static final String VALID_DURATION = "1.5";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -192,5 +200,58 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseString_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseString(null));
+    }
+
+    @Test
+    public void parseString_whitespace_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseString(WHITESPACE));
+    }
+
+    @Test
+    public void parseString_validValue_returnsString() throws Exception {
+        assertEquals(VALID_STRING, ParserUtil.parseString(VALID_STRING));
+        // With whitespace
+        assertEquals(VALID_STRING, ParserUtil.parseString(WHITESPACE + VALID_STRING + WHITESPACE));
+    }
+
+    @Test
+    public void parseRate_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseRate(null));
+    }
+
+    @Test
+    public void parseRate_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseRate(INVALID_RATE));
+    }
+
+    @Test
+    public void parseRate_validValue_returnsRate() throws Exception {
+        Rate expectedRate = new Rate(new Money(3.0), Duration.ofHours(1));
+        assertEquals(expectedRate, ParserUtil.parseRate(VALID_RATE));
+        // With whitespace
+        assertEquals(expectedRate, ParserUtil.parseRate(WHITESPACE + VALID_RATE + WHITESPACE));
+    }
+
+    @Test
+    public void parseDuration_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseDuration(null));
+    }
+
+    @Test
+    public void parseDuration_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDuration(INVALID_RATE));
+    }
+
+    @Test
+    public void parseDuration_validValue_returnsDuration() throws Exception {
+        Duration expectedDuration = Duration.ofMinutes(90);
+        assertEquals(expectedDuration, ParserUtil.parseDuration(VALID_DURATION));
+        // With whitespace
+        assertEquals(expectedDuration, ParserUtil.parseDuration(WHITESPACE + VALID_DURATION + WHITESPACE));
     }
 }

--- a/src/test/java/peoplesoft/logic/parser/job/JobAddCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobAddCommandParserTest.java
@@ -18,11 +18,6 @@ public class JobAddCommandParserTest {
     }
 
     @Test
-    public void parse_nonEmptyPreamble_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse(" preamble"));
-    }
-
-    @Test
     public void parse_wrongFormatArgs_throwsParseException() {
         // Empty name
         assertThrows(ParseException.class, () -> parser.parse(" n/ r/1.0 d/3"));

--- a/src/test/java/peoplesoft/logic/parser/job/JobAddCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobAddCommandParserTest.java
@@ -1,0 +1,37 @@
+package peoplesoft.logic.parser.job;
+
+import static peoplesoft.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import peoplesoft.logic.parser.exceptions.ParseException;
+
+public class JobAddCommandParserTest {
+
+    private JobAddCommandParser parser = new JobAddCommandParser();
+
+    @Test
+    public void parse_missingArgs_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(" n/name r/1.0"));
+        assertThrows(ParseException.class, () -> parser.parse(" n/name d/3"));
+        assertThrows(ParseException.class, () -> parser.parse(" r/1.0 d/3"));
+    }
+
+    @Test
+    public void parse_nonEmptyPreamble_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(" preamble"));
+    }
+
+    @Test
+    public void parse_wrongFormatArgs_throwsParseException() {
+        // Empty name
+        assertThrows(ParseException.class, () -> parser.parse(" n/ r/1.0 d/3"));
+        // Incorrect rate parse
+        assertThrows(ParseException.class, () -> parser.parse(" n/name r/hello d/3"));
+        // Incorrect duration parse
+        assertThrows(ParseException.class, () -> parser.parse(" n/name r/1.0 d/world"));
+    }
+
+    // TODO: create test for successful construction
+    // Current issue is that a new jobId will be made and that may not be deterministic
+}

--- a/src/test/java/peoplesoft/logic/parser/job/JobAssignCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobAssignCommandParserTest.java
@@ -12,13 +12,10 @@ public class JobAssignCommandParserTest {
 
     @Test
     public void parse_missingArgs_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse(" n/name"));
+        // Missing index
+        assertThrows(ParseException.class, () -> parser.parse(" test"));
+        // Missing preamble
         assertThrows(ParseException.class, () -> parser.parse(" i/1"));
-    }
-
-    @Test
-    public void parse_nonEmptyPreamble_throwsParseException() {
-        assertThrows(ParseException.class, () -> parser.parse(" preamble"));
     }
 
     // TODO: create test for successful construction

--- a/src/test/java/peoplesoft/logic/parser/job/JobAssignCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobAssignCommandParserTest.java
@@ -1,0 +1,26 @@
+package peoplesoft.logic.parser.job;
+
+import static peoplesoft.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import peoplesoft.logic.parser.exceptions.ParseException;
+
+public class JobAssignCommandParserTest {
+
+    private JobAssignCommandParser parser = new JobAssignCommandParser();
+
+    @Test
+    public void parse_missingArgs_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(" n/name"));
+        assertThrows(ParseException.class, () -> parser.parse(" i/1"));
+    }
+
+    @Test
+    public void parse_nonEmptyPreamble_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(" preamble"));
+    }
+
+    // TODO: create test for successful construction
+    // Current issue is that a new jobId will be made and that may not be deterministic
+}

--- a/src/test/java/peoplesoft/logic/parser/job/JobDeleteCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobDeleteCommandParserTest.java
@@ -1,0 +1,29 @@
+package peoplesoft.logic.parser.job;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static peoplesoft.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import peoplesoft.logic.parser.exceptions.ParseException;
+
+public class JobDeleteCommandParserTest {
+
+    private static final String VALID_STRING = "valid";
+    private static final String WHITESPACE = " \t\r\n";
+
+    private JobDeleteCommandParser parser = new JobDeleteCommandParser();
+
+    @Test
+    public void parse_whitespace_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(WHITESPACE));
+    }
+
+    @Test
+    public void parse_validValue_returnsString() throws Exception {
+        assertEquals(VALID_STRING, parser.parse(VALID_STRING));
+        // With whitespace
+        assertEquals(VALID_STRING, parser.parse(WHITESPACE + VALID_STRING + WHITESPACE));
+        // TODO: Currently exactly the same as ParserUtil.parseString()
+    }
+}

--- a/src/test/java/peoplesoft/logic/parser/job/JobMarkCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobMarkCommandParserTest.java
@@ -1,0 +1,29 @@
+package peoplesoft.logic.parser.job;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static peoplesoft.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import peoplesoft.logic.parser.exceptions.ParseException;
+
+public class JobMarkCommandParserTest {
+
+    private static final String VALID_STRING = "valid";
+    private static final String WHITESPACE = " \t\r\n";
+
+    private JobMarkCommandParser parser = new JobMarkCommandParser();
+
+    @Test
+    public void parse_whitespace_throwsParseException() {
+        assertThrows(ParseException.class, () -> parser.parse(WHITESPACE));
+    }
+
+    @Test
+    public void parse_validValue_returnsString() throws Exception {
+        assertEquals(VALID_STRING, parser.parse(VALID_STRING));
+        // With whitespace
+        assertEquals(VALID_STRING, parser.parse(WHITESPACE + VALID_STRING + WHITESPACE));
+        // TODO: Currently exactly the same as ParserUtil.parseString()
+    }
+}

--- a/src/test/java/peoplesoft/model/AddressBookSerdesTest.java
+++ b/src/test/java/peoplesoft/model/AddressBookSerdesTest.java
@@ -151,13 +151,14 @@ public class AddressBookSerdesTest {
 
         String serializedEmployment = JsonUtil.toJsonString(Employment.getInstance().getAllJobs());
 
-        String serializedJobIdState = String.valueOf(JobIdFactory.getId());
+        int id = JobIdFactory.getId();
+        String serializedJobIdState = JsonUtil.toJsonString(id);
 
         LinkedHashMap<String, String> map = new LinkedHashMap<>();
         map.put("persons", serializeList(serializedPersonList));
         map.put("jobs", serializeList(List.of())); // TODO
-        map.put("employment", JsonUtil.toJsonString(Employment.getInstance().getAllJobs()));
-        map.put("jobIdState", JsonUtil.toJsonString(JobIdFactory.getId()));
+        map.put("employment", serializedEmployment);
+        map.put("jobIdState", serializedJobIdState);
 
         String serialized = serializeObject(map);
 
@@ -165,7 +166,7 @@ public class AddressBookSerdesTest {
         // Checks if employment and jobIdState gets serialized correctly
         assertEquals(Employment.getInstance().getAllJobs(),
                 JsonUtil.fromJsonString(serializedEmployment, HashMap.class));
-        assertEquals(JobIdFactory.getId(), JsonUtil.fromJsonString(serializedJobIdState, int.class));
+        assertEquals(id, JsonUtil.fromJsonString(serializedJobIdState, int.class));
         // TODO if needed
     }
 }

--- a/src/test/java/peoplesoft/model/AddressBookTest.java
+++ b/src/test/java/peoplesoft/model/AddressBookTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import peoplesoft.model.job.Job;
 import peoplesoft.model.person.Person;
 import peoplesoft.model.person.exceptions.DuplicatePersonException;
 import peoplesoft.testutil.PersonBuilder;
@@ -49,7 +50,7 @@ public class AddressBookTest {
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         List<Person> newPersons = Arrays.asList(ALICE, editedAlice);
-        AddressBookStub newData = new AddressBookStub(newPersons);
+        PersonAddressBookStub newData = new PersonAddressBookStub(newPersons);
 
         assertThrows(DuplicatePersonException.class, () -> addressBook.resetData(newData));
     }
@@ -86,10 +87,10 @@ public class AddressBookTest {
     /**
      * A stub ReadOnlyAddressBook whose persons list can violate interface constraints.
      */
-    private static class AddressBookStub implements ReadOnlyAddressBook {
+    private static class PersonAddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
 
-        AddressBookStub(Collection<Person> persons) {
+        PersonAddressBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
         }
 
@@ -97,6 +98,12 @@ public class AddressBookTest {
         public ObservableList<Person> getPersonList() {
             return persons;
         }
+
+        @Override
+        public ObservableList<Job> getJobList() {
+            return FXCollections.observableArrayList();
+        }
     }
 
+    // TODO: JobAddressBookStub
 }

--- a/src/test/java/peoplesoft/model/job/JobTest.java
+++ b/src/test/java/peoplesoft/model/job/JobTest.java
@@ -2,27 +2,18 @@ package peoplesoft.model.job;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static peoplesoft.testutil.Assert.assertThrows;
-import static peoplesoft.testutil.TypicalPersons.ALICE;
-import static peoplesoft.testutil.TypicalPersons.BOB;
 
 import java.math.BigDecimal;
 import java.time.Duration;
-import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
 class JobTest {
 
     private static final Job EATING = new Job("1043", "Eating",
-            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), false, Set.of(ALICE));
+            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), false);
     private static final Job RUNNING = new Job("3175", "Running",
-            new Rate(new Money(6), Duration.ofHours(4)), Duration.ofHours(8), true, Set.of(BOB));
-
-    @Test
-    public void getPersons_modifyList_throwsUnsupportedOperationException() {
-        assertThrows(UnsupportedOperationException.class, () -> EATING.getPersons().remove(0));
-    }
+            new Rate(new Money(6), Duration.ofHours(4)), Duration.ofHours(8), true);
 
     @Test
     public void calculatePay() {
@@ -51,7 +42,7 @@ class JobTest {
 
         // same values -> returns true
         assertTrue(EATING.equals(new Job("1043", "Eating",
-            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), false, Set.of(ALICE))));
+            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), false)));
 
         // null -> returns false
         assertFalse(EATING.equals(null));
@@ -62,18 +53,16 @@ class JobTest {
         // another value -> returns false
         assertFalse(EATING.equals(RUNNING));
         assertFalse(EATING.equals(new Job("1044", "Eating",
-            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), false, Set.of(ALICE))));
+            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), false)));
         assertFalse(EATING.equals(new Job("1043", "Eating",
-            new Rate(new Money(5.5), Duration.ofHours(2)), Duration.ofDays(1), false, Set.of(ALICE))));
+            new Rate(new Money(5.5), Duration.ofHours(2)), Duration.ofDays(1), false)));
         assertFalse(EATING.equals(new Job("1043", "Running",
-            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), false, Set.of(ALICE))));
+            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), false)));
         assertFalse(EATING.equals(new Job("1043", "Eating",
-            new Rate(new Money(6), Duration.ofHours(1)), Duration.ofDays(1), false, Set.of(ALICE))));
+            new Rate(new Money(6), Duration.ofHours(1)), Duration.ofDays(1), false)));
         assertFalse(EATING.equals(new Job("1043", "Eating",
-            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(2), false, Set.of(ALICE))));
+            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(2), false)));
         assertFalse(EATING.equals(new Job("1043", "Eating",
-            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), true, Set.of(ALICE))));
-        assertFalse(EATING.equals(new Job("1043", "Eating",
-            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), false, Set.of(BOB))));
+            new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), true)));
     }
 }


### PR DESCRIPTION
Also updates `Model` and `AddressBook` to handle jobs.

Currently adds the following commands:
- JobAddCommand: Adding a job
- JobDeleteCommand: Deletes a job
- JobListCommand: Lists all jobs (in the console)
- JobMarkCommand: Marks a job as paid or unpaid
- JobAssignCommand: Assigns a job to a person

Issues needing resolution/follow-up:
- [ ] Implement UI to display jobs
- [x] Serdes of joblist
- [x] Serdes of employment (job-person association)
- [x] `JobIdFactory` does not consider job IDs of serialized jobs
- [ ] Testing of `JobAddCommand` since job IDs are non-deterministic
  - [x] Framework in place
- [ ] More in-depth test cases for commands (automated testing)
  - [x] `JobDeleteCommand`

Feel free to push to the branch to modify anything. Automated tests are lacking, but features have been manually tested.