### PR TITLE
Assign `Rate` attribute to `Person`

### DIFF
--- a/data.example/addressbook.json
+++ b/data.example/addressbook.json
@@ -1,34 +1,62 @@
 {
   "persons" : [ {
+    "id" : "1",
     "name" : "Nicole Tan",
     "phone" : "99338558",
     "email" : "nicole@stffhub.org",
     "address" : "1 Tech Drive, S138572",
+    "rate" : {
+      "amount" : "30.000000",
+      "duration" : "PT1H"
+    },
     "tagged" : [ "Intern", "Aircon" ]
   }, {
+    "id" : "2",
     "name" : "Kavya Singh",
     "phone" : "96736637",
     "email" : "kavya@stffhub.org",
     "address" : "2 Orchard Turn, S238801",
+    "rate" : {
+      "amount" : "40.000000",
+      "duration" : "PT1H"
+    },
     "tagged" : [ "Senior", "Electrician" ]
   }, {
+    "id" : "3",
     "name" : "Ethan Lee",
     "phone" : "91031282",
     "email" : "ethan@stffhub.org",
     "address" : "10 Anson Road, S079903",
+    "rate" : {
+      "amount" : "20.000000",
+      "duration" : "PT1H"
+    },
     "tagged" : [ "Appliances" ]
   }, {
+    "id" : "4",
     "name" : "Irfan Ibrahim",
     "phone" : "92492021",
     "email" : "irfan@stffhub.org",
     "address" : "Blk 47 Tampines Street 20, #17-35",
+    "rate" : {
+      "amount" : "48.000000",
+      "duration" : "PT1H"
+    },
     "tagged" : [ "Painting" ]
   }, {
+    "id" : "5",
     "name" : "Arjun Khatau",
     "phone" : "80445044",
     "email" : "arjun@stffhub.org",
     "address" : "50 Collyer Quay, S049321",
+    "rate" : {
+      "amount" : "33.000000",
+      "duration" : "PT1H"
+    },
     "tagged" : [ "Contract", "Aircon" ]
   } ],
-  "jobs" : [ ]
+  "jobs" : [ ],
+  "employment" : { },
+  "jobIdState" : 0,
+  "personIdState" : 0
 }

--- a/src/main/java/peoplesoft/logic/commands/AddCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/AddCommand.java
@@ -5,6 +5,7 @@ import static peoplesoft.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_PHONE;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_RATE;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_TAG;
 
 import peoplesoft.logic.commands.exceptions.CommandException;
@@ -24,12 +25,14 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
+            + PREFIX_RATE + "RATE "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
+            + PREFIX_RATE + "3.20 "
             + PREFIX_TAG + "Intern "
             + PREFIX_TAG + "Painting";
 

--- a/src/main/java/peoplesoft/logic/commands/EditCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/EditCommand.java
@@ -5,6 +5,7 @@ import static peoplesoft.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_PHONE;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_RATE;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_TAG;
 import static peoplesoft.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -19,6 +20,7 @@ import peoplesoft.commons.core.index.Index;
 import peoplesoft.commons.util.CollectionUtil;
 import peoplesoft.logic.commands.exceptions.CommandException;
 import peoplesoft.model.Model;
+import peoplesoft.model.job.Rate;
 import peoplesoft.model.person.Address;
 import peoplesoft.model.person.Email;
 import peoplesoft.model.person.Name;
@@ -42,6 +44,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
+            + "[" + PREFIX_RATE + "RATE] "
             + "[" + PREFIX_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
@@ -100,10 +103,11 @@ public class EditCommand extends Command {
         Phone updatedPhone = editPersonDescriptor.getPhone().orElse(personToEdit.getPhone());
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
+        Rate updatedRate = editPersonDescriptor.getRate().orElse(personToEdit.getRate());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
 
         return new Person(personToEdit.getPersonId(),
-            updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+            updatedName, updatedPhone, updatedEmail, updatedAddress, updatedRate, updatedTags);
     }
 
     @Override
@@ -133,6 +137,7 @@ public class EditCommand extends Command {
         private Phone phone;
         private Email email;
         private Address address;
+        private Rate rate;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {}
@@ -146,6 +151,7 @@ public class EditCommand extends Command {
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
             setAddress(toCopy.address);
+            setRate(toCopy.rate);
             setTags(toCopy.tags);
         }
 
@@ -186,6 +192,14 @@ public class EditCommand extends Command {
 
         public Optional<Address> getAddress() {
             return Optional.ofNullable(address);
+        }
+
+        public void setRate(Rate rate) {
+            this.rate = rate;
+        }
+
+        public Optional<Rate> getRate() {
+            return Optional.ofNullable(rate);
         }
 
         /**

--- a/src/main/java/peoplesoft/logic/commands/job/JobListCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobListCommand.java
@@ -22,6 +22,7 @@ public class JobListCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         // TODO: UI interaction, currently prints to console
+        model.updateFilteredJobList(Model.PREDICATE_SHOW_ALL_JOBS);
         return new CommandResult(String.format(MESSAGE_SUCCESS, model.getFilteredJobList(),
                 Employment.getInstance().getAllJobs()));
     }

--- a/src/main/java/peoplesoft/logic/parser/AddCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/AddCommandParser.java
@@ -5,6 +5,7 @@ import static peoplesoft.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_PHONE;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_RATE;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Set;
@@ -13,6 +14,7 @@ import java.util.stream.Stream;
 import peoplesoft.commons.core.PersonIdFactory;
 import peoplesoft.logic.commands.AddCommand;
 import peoplesoft.logic.parser.exceptions.ParseException;
+import peoplesoft.model.job.Rate;
 import peoplesoft.model.person.Address;
 import peoplesoft.model.person.Email;
 import peoplesoft.model.person.Name;
@@ -32,9 +34,10 @@ public class AddCommandParser implements Parser<AddCommand> {
      */
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_RATE, PREFIX_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_RATE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
@@ -43,9 +46,10 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
+        Rate rate = ParserUtil.parseRate(argMultimap.getValue(PREFIX_RATE).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(PersonIdFactory.nextId(), name, phone, email, address, tagList);
+        Person person = new Person(PersonIdFactory.nextId(), name, phone, email, address, rate, tagList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/peoplesoft/logic/parser/EditCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/EditCommandParser.java
@@ -6,6 +6,7 @@ import static peoplesoft.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_PHONE;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_RATE;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collection;
@@ -32,7 +33,8 @@ public class EditCommandParser implements Parser<EditCommand> {
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS,
+                        PREFIX_RATE, PREFIX_TAG);
 
         Index index;
 
@@ -54,6 +56,9 @@ public class EditCommandParser implements Parser<EditCommand> {
         }
         if (argMultimap.getValue(PREFIX_ADDRESS).isPresent()) {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
+        }
+        if (argMultimap.getValue(PREFIX_RATE).isPresent()) {
+            editPersonDescriptor.setRate(ParserUtil.parseRate(argMultimap.getValue(PREFIX_RATE).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
 

--- a/src/main/java/peoplesoft/logic/parser/ParserUtil.java
+++ b/src/main/java/peoplesoft/logic/parser/ParserUtil.java
@@ -155,7 +155,7 @@ public class ParserUtil {
             res = new Rate(new Money(Double.parseDouble(trim)), Duration.ofHours(1));
         } catch (NumberFormatException e) {
             // TODO: add message/complex rate parsing %s/%s
-            throw new ParseException("Invalid value for rate");
+            throw new ParseException(Rate.MESSAGE_CONSTRAINTS);
         }
         return res;
     }

--- a/src/main/java/peoplesoft/model/job/Rate.java
+++ b/src/main/java/peoplesoft/model/job/Rate.java
@@ -34,6 +34,7 @@ import peoplesoft.commons.util.JsonUtil;
 @JsonSerialize(using = Rate.RateSerializer.class)
 @JsonDeserialize(using = Rate.RateDeserializer.class)
 public class Rate {
+    public static final String MESSAGE_CONSTRAINTS = "Value for rate should be a decimal number";
 
     public final Money amount;
     public final Duration duration;

--- a/src/main/java/peoplesoft/model/person/Person.java
+++ b/src/main/java/peoplesoft/model/person/Person.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 
 import peoplesoft.commons.util.JsonUtil;
+import peoplesoft.model.job.Rate;
 import peoplesoft.model.tag.Tag;
 import peoplesoft.model.util.ID;
 
@@ -45,18 +46,20 @@ public class Person {
 
     // Data fields
     private final Address address;
+    private final Rate rate;
     private final Set<Tag> tags = new HashSet<>();
 
     /**
      * Every field must be present and not null.
      */
-    public Person(ID id, Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        requireAllNonNull(id, name, phone, email, address, tags);
+    public Person(ID id, Name name, Phone phone, Email email, Address address, Rate rate, Set<Tag> tags) {
+        requireAllNonNull(id, name, phone, email, address, rate, tags);
         this.id = id;
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
+        this.rate = rate;
         this.tags.addAll(tags);
     }
 
@@ -78,6 +81,10 @@ public class Person {
 
     public Address getAddress() {
         return address;
+    }
+
+    public Rate getRate() {
+        return rate;
     }
 
     /**
@@ -121,13 +128,14 @@ public class Person {
                 && otherPerson.getPhone().equals(getPhone())
                 && otherPerson.getEmail().equals(getEmail())
                 && otherPerson.getAddress().equals(getAddress())
+                && otherPerson.getRate().equals(getRate())
                 && otherPerson.getTags().equals(getTags());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(id, name, phone, email, address, tags);
+        return Objects.hash(id, name, phone, email, address, rate, tags);
     }
 
     @Override
@@ -142,7 +150,9 @@ public class Person {
                 .append("; Email: ")
                 .append(getEmail())
                 .append("; Address: ")
-                .append(getAddress());
+                .append(getAddress())
+                .append("; Base Pay Rate: ")
+                .append(getRate());
 
         Set<Tag> tags = getTags();
         if (!tags.isEmpty()) {
@@ -170,6 +180,7 @@ public class Person {
             gen.writeObjectField("phone", val.getPhone());
             gen.writeObjectField("email", val.getEmail());
             gen.writeObjectField("address", val.getAddress());
+            gen.writeObjectField("rate", val.getRate());
             gen.writeObjectField("tagged", val.getTags());
 
             gen.writeEndObject();
@@ -190,19 +201,19 @@ public class Person {
         }
 
         private static JsonNode getNonNullNode(ObjectNode node, String key, DeserializationContext ctx)
-                throws JsonMappingException {
+                    throws JsonMappingException {
             return JsonUtil.getNonNullNode(node, key, ctx, INVALID_VAL_FMTR);
         }
 
         private static <T> T getNonNullNodeWithType(ObjectNode node, String key, DeserializationContext ctx,
-                Class<T> cls) throws JsonMappingException {
+                    Class<T> cls) throws JsonMappingException {
             return JsonUtil.getNonNullNodeWithType(node, key, ctx,
-                INVALID_VAL_FMTR, cls);
+                    INVALID_VAL_FMTR, cls);
         }
 
         @Override
         public Person deserialize(JsonParser p, DeserializationContext ctx)
-                throws IOException, JsonProcessingException {
+                    throws IOException, JsonProcessingException {
             JsonNode node = p.readValueAsTree();
             ObjectCodec codec = p.getCodec();
 
@@ -213,30 +224,34 @@ public class Person {
             ObjectNode person = (ObjectNode) node;
 
             ID id = getNonNullNode(person, "id", ctx)
-                .traverse(codec)
-                .readValueAs(ID.class);
+                    .traverse(codec)
+                    .readValueAs(ID.class);
 
             Name name = getNonNullNode(person, "name", ctx)
-                .traverse(codec)
-                .readValueAs(Name.class);
+                    .traverse(codec)
+                    .readValueAs(Name.class);
 
             Phone phone = getNonNullNode(person, "phone", ctx)
-                .traverse(codec)
-                .readValueAs(Phone.class);
+                    .traverse(codec)
+                    .readValueAs(Phone.class);
 
             Email email = getNonNullNode(person, "email", ctx)
-                .traverse(codec)
-                .readValueAs(Email.class);
+                    .traverse(codec)
+                    .readValueAs(Email.class);
 
             Address address = getNonNullNode(person, "address", ctx)
-                .traverse(codec)
-                .readValueAs(Address.class);
+                    .traverse(codec)
+                    .readValueAs(Address.class);
+
+            Rate rate = getNonNullNode(person, "rate", ctx)
+                    .traverse(codec)
+                    .readValueAs(Rate.class);
 
             Set<Tag> tags = getNonNullNodeWithType(person, "tagged", ctx, ArrayNode.class)
-                .traverse(codec)
-                .readValueAs(new TypeReference<Set<Tag>>(){});
+                    .traverse(codec)
+                    .readValueAs(new TypeReference<Set<Tag>>(){});
 
-            return new Person(id, name, phone, email, address, tags);
+            return new Person(id, name, phone, email, address, rate, tags);
         }
 
         @Override

--- a/src/main/java/peoplesoft/model/util/SampleDataUtil.java
+++ b/src/main/java/peoplesoft/model/util/SampleDataUtil.java
@@ -1,11 +1,14 @@
 package peoplesoft.model.util;
 
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import peoplesoft.model.AddressBook;
 import peoplesoft.model.ReadOnlyAddressBook;
+import peoplesoft.model.job.Money;
+import peoplesoft.model.job.Rate;
 import peoplesoft.model.person.Address;
 import peoplesoft.model.person.Email;
 import peoplesoft.model.person.Name;
@@ -20,19 +23,19 @@ public class SampleDataUtil {
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new ID(1), new Name("Nicole Tan"), new Phone("99338558"), new Email("nicole@stffhub.org"),
-                new Address("1 Tech Drive, S138572"),
+                new Address("1 Tech Drive, S138572"), new Rate(new Money(30), Duration.ofHours(1)),
                 getTagSet("Intern", "Aircon")),
             new Person(new ID(2), new Name("Kavya Singh"), new Phone("96736637"), new Email("kavya@stffhub.org"),
-                new Address("2 Orchard Turn, S238801"),
+                new Address("2 Orchard Turn, S238801"), new Rate(new Money(40), Duration.ofHours(1)),
                 getTagSet("Senior", "Electrician")),
             new Person(new ID(3), new Name("Ethan Lee"), new Phone("91031282"), new Email("ethan@stffhub.org"),
-                new Address("10 Anson Road, S079903"),
+                new Address("10 Anson Road, S079903"), new Rate(new Money(20), Duration.ofHours(1)),
                 getTagSet("Appliances")),
             new Person(new ID(4), new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@stffhub.org"),
-                new Address("Blk 47 Tampines Street 20, #17-35"),
+                new Address("Blk 47 Tampines Street 20, #17-35"), new Rate(new Money(48), Duration.ofHours(1)),
                 getTagSet("Painting")),
             new Person(new ID(5), new Name("Arjun Khatau"), new Phone("80445044"), new Email("arjun@stffhub.org"),
-                new Address("50 Collyer Quay, S049321"),
+                new Address("50 Collyer Quay, S049321"), new Rate(new Money(33), Duration.ofHours(1)),
                 getTagSet("Contract", "Aircon"))
         };
     }

--- a/src/test/java/peoplesoft/logic/LogicManagerTest.java
+++ b/src/test/java/peoplesoft/logic/LogicManagerTest.java
@@ -7,6 +7,7 @@ import static peoplesoft.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static peoplesoft.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static peoplesoft.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static peoplesoft.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static peoplesoft.logic.commands.CommandTestUtil.RATE_DESC_AMY;
 import static peoplesoft.testutil.Assert.assertThrows;
 import static peoplesoft.testutil.TypicalPersons.AMY;
 
@@ -80,7 +81,7 @@ public class LogicManagerTest {
 
         // Execute add command
         String addCommand = AddCommand.COMMAND_WORD + NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY
-                + ADDRESS_DESC_AMY;
+                + ADDRESS_DESC_AMY + RATE_DESC_AMY;
         Person expectedPerson = new PersonBuilder(AMY)
             .withNextId()
             .withTags()

--- a/src/test/java/peoplesoft/logic/commands/CommandTestUtil.java
+++ b/src/test/java/peoplesoft/logic/commands/CommandTestUtil.java
@@ -6,6 +6,7 @@ import static peoplesoft.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_PHONE;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_RATE;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_TAG;
 import static peoplesoft.testutil.Assert.assertThrows;
 
@@ -34,6 +35,8 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
+    public static final double VALID_RATE_AMY = 1.50;
+    public static final double VALID_RATE_BOB = 12.7;
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
 
@@ -45,6 +48,8 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
+    public static final String RATE_DESC_AMY = " " + PREFIX_RATE + VALID_RATE_AMY;
+    public static final String RATE_DESC_BOB = " " + PREFIX_RATE + VALID_RATE_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
 
@@ -52,6 +57,7 @@ public class CommandTestUtil {
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
+    public static final String INVALID_RATE_DESC = " " + PREFIX_RATE + "string"; // string not allowed for rates
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";

--- a/src/test/java/peoplesoft/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/AddCommandParserTest.java
@@ -9,6 +9,7 @@ import static peoplesoft.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static peoplesoft.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static peoplesoft.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static peoplesoft.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static peoplesoft.logic.commands.CommandTestUtil.INVALID_RATE_DESC;
 import static peoplesoft.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static peoplesoft.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static peoplesoft.logic.commands.CommandTestUtil.NAME_DESC_BOB;
@@ -16,12 +17,15 @@ import static peoplesoft.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static peoplesoft.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static peoplesoft.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
+import static peoplesoft.logic.commands.CommandTestUtil.RATE_DESC_AMY;
+import static peoplesoft.logic.commands.CommandTestUtil.RATE_DESC_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static peoplesoft.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static peoplesoft.logic.commands.CommandTestUtil.VALID_RATE_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -32,6 +36,7 @@ import static peoplesoft.testutil.TypicalPersons.BOB;
 import org.junit.jupiter.api.Test;
 
 import peoplesoft.logic.commands.AddCommand;
+import peoplesoft.model.job.Rate;
 import peoplesoft.model.person.Address;
 import peoplesoft.model.person.Email;
 import peoplesoft.model.person.Name;
@@ -49,42 +54,47 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + RATE_DESC_BOB + TAG_DESC_FRIEND,
             new AddCommand(expectedPersonBuilder.withNextId().build()));
 
         // multiple names - last name accepted
         assertParseSuccess(parser, NAME_DESC_AMY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + RATE_DESC_BOB + TAG_DESC_FRIEND,
             new AddCommand(expectedPersonBuilder.withNextId().build()));
 
         // multiple phones - last phone accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_AMY + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + RATE_DESC_BOB + TAG_DESC_FRIEND,
             new AddCommand(expectedPersonBuilder.withNextId().build()));
 
         // multiple emails - last email accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_AMY + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + RATE_DESC_BOB + TAG_DESC_FRIEND,
             new AddCommand(expectedPersonBuilder.withNextId().build()));
 
         // multiple addresses - last address accepted
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_AMY
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + RATE_DESC_BOB + TAG_DESC_FRIEND,
+            new AddCommand(expectedPersonBuilder.withNextId().build()));
+
+        // multiple rates - last rate accepted
+        assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + RATE_DESC_AMY + RATE_DESC_BOB + TAG_DESC_FRIEND,
             new AddCommand(expectedPersonBuilder.withNextId().build()));
 
         // multiple tags - all accepted
         Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
                 .withNextId().build();
         assertParseSuccess(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedPersonMultipleTags));
+                + RATE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedPersonMultipleTags));
     }
 
     @Test
     public void parse_optionalFieldsMissing_success() {
         // zero tags
         Person expectedPerson = new PersonBuilder(AMY).withTags().withNextId().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY,
-                new AddCommand(expectedPerson));
+        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
+                + RATE_DESC_AMY, new AddCommand(expectedPerson));
     }
 
     @Test
@@ -92,55 +102,63 @@ public class AddCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
         // missing name prefix
-        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + RATE_DESC_BOB, expectedMessage);
 
         // missing phone prefix
-        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser, NAME_DESC_BOB + VALID_PHONE_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + RATE_DESC_BOB, expectedMessage);
 
         // missing email prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB,
-                expectedMessage);
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + VALID_EMAIL_BOB + ADDRESS_DESC_BOB
+                + RATE_DESC_BOB, expectedMessage);
 
         // missing address prefix
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB,
-                expectedMessage);
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + VALID_ADDRESS_BOB
+                + RATE_DESC_BOB, expectedMessage);
+
+        // missing rate prefix
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + VALID_RATE_BOB, expectedMessage);
 
         // all prefixes missing
-        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB,
-                expectedMessage);
+        assertParseFailure(parser, VALID_NAME_BOB + VALID_PHONE_BOB + VALID_EMAIL_BOB + VALID_ADDRESS_BOB
+                + VALID_RATE_BOB, expectedMessage);
     }
 
     @Test
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + RATE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + RATE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+                + RATE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
 
         // invalid address
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
+                + RATE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
+
+        // invalid rate
+        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
+                + INVALID_RATE_DESC + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Rate.MESSAGE_CONSTRAINTS);
 
         // invalid tag
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + RATE_DESC_BOB + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
 
         // two invalid values, only first invalid value reported
-        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,
-                Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
+                + RATE_DESC_BOB, Name.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + RATE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/peoplesoft/model/AddressBookSerdesTest.java
+++ b/src/test/java/peoplesoft/model/AddressBookSerdesTest.java
@@ -128,6 +128,7 @@ public class AddressBookSerdesTest {
                 BENSON.getPhone().toString(),
                 BENSON.getAddress().toString(),
                 BENSON.getEmail().toString(),
+                BENSON.getRate().getAmount().printFullValue(),
                 Collections.singleton("friend")),
             serializePerson(ELLE)));
 

--- a/src/test/java/peoplesoft/model/person/PersonSerdesTest.java
+++ b/src/test/java/peoplesoft/model/person/PersonSerdesTest.java
@@ -24,6 +24,7 @@ public class PersonSerdesTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_RATE = "string";
     private static final Set<String> INVALID_TAGS = Collections.singleton("#friend");
 
     private static final String VALID_PERSONID = BENSON.getPersonId().toString();
@@ -31,6 +32,7 @@ public class PersonSerdesTest {
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
+    private static final String VALID_RATE = BENSON.getRate().getAmount().printFullValue();
     private static final Set<String> VALID_TAGS =
         BENSON.getTags().stream().map((tag) -> tag.tagName).collect(Collectors.toSet());
 
@@ -61,7 +63,7 @@ public class PersonSerdesTest {
     @Test
     public void deserialize_nullPersonId_throwsJsonMappingException() {
         final String serialized = serializePerson(
-            null, VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL, VALID_TAGS);
+            null, VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL, VALID_RATE, VALID_TAGS);
 
         assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
     }
@@ -69,7 +71,7 @@ public class PersonSerdesTest {
     @Test
     public void deserialize_invalidName_throwsJsonMappingException() throws IOException {
         final String serialized = serializePerson(
-            VALID_PERSONID, INVALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL, VALID_TAGS);
+            VALID_PERSONID, INVALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL, VALID_RATE, VALID_TAGS);
 
         assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
     }
@@ -77,7 +79,7 @@ public class PersonSerdesTest {
     @Test
     public void deserialize_nullName_throwsJsonMappingException() {
         final String serialized = serializePerson(
-            VALID_PERSONID, null, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL, VALID_TAGS);
+            VALID_PERSONID, null, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL, VALID_RATE, VALID_TAGS);
 
         assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
     }
@@ -85,7 +87,7 @@ public class PersonSerdesTest {
     @Test
     public void deserialize_invalidPhone_throwsJsonMappingException() {
         final String serialized = serializePerson(
-            VALID_PERSONID, VALID_NAME, INVALID_PHONE, VALID_ADDRESS, VALID_EMAIL, VALID_TAGS);
+            VALID_PERSONID, VALID_NAME, INVALID_PHONE, VALID_ADDRESS, VALID_EMAIL, VALID_RATE, VALID_TAGS);
 
         assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
     }
@@ -93,7 +95,7 @@ public class PersonSerdesTest {
     @Test
     public void deserialize_nullPhone_throwsJsonMappingException() {
         final String serialized = serializePerson(
-            VALID_PERSONID, VALID_NAME, null, VALID_ADDRESS, VALID_EMAIL, VALID_TAGS);
+            VALID_PERSONID, VALID_NAME, null, VALID_ADDRESS, VALID_EMAIL, VALID_RATE, VALID_TAGS);
 
         assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
     }
@@ -101,7 +103,7 @@ public class PersonSerdesTest {
     @Test
     public void deserialize_invalidEmail_throwsJsonMappingException() {
         final String serialized = serializePerson(
-            VALID_PERSONID, VALID_NAME, VALID_PHONE, VALID_ADDRESS, INVALID_EMAIL, VALID_TAGS);
+            VALID_PERSONID, VALID_NAME, VALID_PHONE, VALID_ADDRESS, INVALID_EMAIL, VALID_RATE, VALID_TAGS);
 
         assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
     }
@@ -109,7 +111,7 @@ public class PersonSerdesTest {
     @Test
     public void deserialize_nullEmail_throwsJsonMappingException() {
         final String serialized = serializePerson(
-            VALID_PERSONID, VALID_NAME, VALID_PHONE, VALID_ADDRESS, null, VALID_TAGS);
+            VALID_PERSONID, VALID_NAME, VALID_PHONE, VALID_ADDRESS, null, VALID_RATE, VALID_TAGS);
 
         assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
     }
@@ -117,7 +119,7 @@ public class PersonSerdesTest {
     @Test
     public void deserialize_invalidAddress_throwsJsonMappingException() {
         final String serialized = serializePerson(
-            VALID_PERSONID, VALID_NAME, VALID_PHONE, INVALID_ADDRESS, VALID_EMAIL, VALID_TAGS);
+            VALID_PERSONID, VALID_NAME, VALID_PHONE, INVALID_ADDRESS, VALID_EMAIL, VALID_RATE, VALID_TAGS);
 
         assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
     }
@@ -125,15 +127,33 @@ public class PersonSerdesTest {
     @Test
     public void deserialize_nullAddress_throwsJsonMappingException() {
         final String serialized = serializePerson(
-            VALID_PERSONID, VALID_NAME, VALID_PHONE, null, VALID_EMAIL, VALID_TAGS);
+            VALID_PERSONID, VALID_NAME, VALID_PHONE, null, VALID_EMAIL, VALID_RATE, VALID_TAGS);
 
         assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
     }
 
     @Test
+    public void deserialize_invalidRate_throwsJsonMappingException() {
+        final String serialized = serializePerson(
+            VALID_PERSONID, VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL, INVALID_RATE, VALID_TAGS);
+
+        assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
+    }
+
+    @Test
+    public void deserialize_nullRate_throwsJsonMappingException() {
+        final String serialized = serializePerson(
+            VALID_PERSONID, VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL, null, VALID_TAGS);
+
+        assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
+    }
+
+
+
+    @Test
     public void deserialize_invalidTags_throwsJsonMappingException() {
         final String serialized = serializePerson(
-            VALID_PERSONID, VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL, INVALID_TAGS);
+            VALID_PERSONID, VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL, VALID_RATE, INVALID_TAGS);
 
         assertThrows(JsonMappingException.class, () -> JsonUtil.fromJsonString(serialized, Person.class));
     }
@@ -147,7 +167,7 @@ public class PersonSerdesTest {
     @Test
     public void deserialize_invalidTagArray_throwsJsonMappingExceptionWithMsg() {
         final String serialized = serializePerson(
-            VALID_PERSONID, VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL,
+            VALID_PERSONID, VALID_NAME, VALID_PHONE, VALID_ADDRESS, VALID_EMAIL, VALID_RATE,
             "\"invalid tag array representation\"");
 
         JsonMappingException ex = assertThrows(

--- a/src/test/java/peoplesoft/model/person/PersonTest.java
+++ b/src/test/java/peoplesoft/model/person/PersonTest.java
@@ -6,6 +6,7 @@ import static peoplesoft.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static peoplesoft.logic.commands.CommandTestUtil.VALID_RATE_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static peoplesoft.testutil.Assert.assertThrows;
 import static peoplesoft.testutil.TypicalPersons.ALICE;
@@ -38,6 +39,7 @@ public class PersonTest {
             .withPhone(VALID_PHONE_BOB)
             .withEmail(VALID_EMAIL_BOB)
             .withAddress(VALID_ADDRESS_BOB)
+            .withRate(VALID_RATE_BOB)
             .withTags(VALID_TAG_HUSBAND)
             .build();
         assertTrue(ALICE.isSamePerson(editedAlice));
@@ -79,6 +81,10 @@ public class PersonTest {
 
         // different address -> returns false
         editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different rate -> returns false
+        editedAlice = new PersonBuilder(ALICE).withRate(VALID_RATE_BOB).build();
         assertFalse(ALICE.equals(editedAlice));
 
         // different tags -> returns false

--- a/src/test/java/peoplesoft/model/person/UniquePersonListSerdesTest.java
+++ b/src/test/java/peoplesoft/model/person/UniquePersonListSerdesTest.java
@@ -107,6 +107,7 @@ public class UniquePersonListSerdesTest {
                 BENSON.getPhone().toString(),
                 BENSON.getAddress().toString(),
                 BENSON.getEmail().toString(),
+                BENSON.getRate().getAmount().printFullValue(), // TODO
                 Collections.singleton("friend")),
             serializePerson(ELLE)));
 

--- a/src/test/java/peoplesoft/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/peoplesoft/testutil/EditPersonDescriptorBuilder.java
@@ -1,10 +1,13 @@
 package peoplesoft.testutil;
 
+import java.time.Duration;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import peoplesoft.logic.commands.EditCommand.EditPersonDescriptor;
+import peoplesoft.model.job.Money;
+import peoplesoft.model.job.Rate;
 import peoplesoft.model.person.Address;
 import peoplesoft.model.person.Email;
 import peoplesoft.model.person.Name;
@@ -36,6 +39,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setPhone(person.getPhone());
         descriptor.setEmail(person.getEmail());
         descriptor.setAddress(person.getAddress());
+        descriptor.setRate(person.getRate());
         descriptor.setTags(person.getTags());
     }
 
@@ -68,6 +72,14 @@ public class EditPersonDescriptorBuilder {
      */
     public EditPersonDescriptorBuilder withAddress(String address) {
         descriptor.setAddress(new Address(address));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Rate} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withRate(double rate) {
+        descriptor.setRate(new Rate(new Money(rate), Duration.ofHours(1)));
         return this;
     }
 

--- a/src/test/java/peoplesoft/testutil/PersonBuilder.java
+++ b/src/test/java/peoplesoft/testutil/PersonBuilder.java
@@ -2,10 +2,13 @@ package peoplesoft.testutil;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
 
 import peoplesoft.commons.core.PersonIdFactory;
+import peoplesoft.model.job.Money;
+import peoplesoft.model.job.Rate;
 import peoplesoft.model.person.Address;
 import peoplesoft.model.person.Email;
 import peoplesoft.model.person.Name;
@@ -24,12 +27,14 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+    public static final double DEFAULT_RATE = 1.50;
 
     private ID personId;
     private Name name;
     private Phone phone;
     private Email email;
     private Address address;
+    private Rate rate;
     private Set<Tag> tags;
 
     /**
@@ -41,6 +46,7 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
+        rate = new Rate(new Money(DEFAULT_RATE), Duration.ofHours(1));
         tags = new HashSet<>();
     }
 
@@ -53,6 +59,7 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
+        rate = personToCopy.getRate();
         tags = new HashSet<>(personToCopy.getTags());
     }
 
@@ -119,8 +126,16 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Rate} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withRate(double rate) {
+        this.rate = new Rate(new Money(rate), Duration.ofHours(1));
+        return this;
+    }
+
     public Person build() {
-        return new Person(personId, name, phone, email, address, tags);
+        return new Person(personId, name, phone, email, address, rate, tags);
     }
 
 }

--- a/src/test/java/peoplesoft/testutil/PersonUtil.java
+++ b/src/test/java/peoplesoft/testutil/PersonUtil.java
@@ -4,6 +4,7 @@ import static peoplesoft.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_PHONE;
+import static peoplesoft.logic.parser.CliSyntax.PREFIX_RATE;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.LinkedHashMap;
@@ -37,6 +38,8 @@ public class PersonUtil {
         sb.append(PREFIX_PHONE + person.getPhone().value + " ");
         sb.append(PREFIX_EMAIL + person.getEmail().value + " ");
         sb.append(PREFIX_ADDRESS + person.getAddress().value + " ");
+        // TODO might need more elegance
+        sb.append(PREFIX_RATE + person.getRate().getAmount().printFullValue() + " ");
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
@@ -52,6 +55,8 @@ public class PersonUtil {
         descriptor.getPhone().ifPresent(phone -> sb.append(PREFIX_PHONE).append(phone.value).append(" "));
         descriptor.getEmail().ifPresent(email -> sb.append(PREFIX_EMAIL).append(email.value).append(" "));
         descriptor.getAddress().ifPresent(address -> sb.append(PREFIX_ADDRESS).append(address.value).append(" "));
+        descriptor.getRate().ifPresent(rate -> sb.append(PREFIX_RATE).append(rate.getAmount().printFullValue())
+                .append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {
@@ -76,6 +81,7 @@ public class PersonUtil {
             person.getPhone().toString(),
             person.getAddress().toString(),
             person.getEmail().toString(),
+            person.getRate().getAmount().printFullValue(), // TODO
             person.getTags().stream().map((tag) -> tag.tagName).collect(Collectors.toSet()));
     }
 
@@ -86,17 +92,19 @@ public class PersonUtil {
      * @param phone the string representation of the {@code Person}'s phone number
      * @param address the string representation of the {@code Person}'s address
      * @param email the string representation of the {@code Person}'s email address
+     * @param rate the string representation of the {@code Person}'s rate
      * @param tags a {@code Set} of the tags assigned to the {@code Person}
      * @return a JSON serialization of the given {@code Person}
      */
     public static String serializePerson(String personId, String name, String phone, String address, String email,
-            Set<String> tags) {
+                String rate, Set<String> tags) {
         return serializePerson(
             personId,
             name,
             phone,
             address,
             email,
+            rate,
             TestUtil.serializeList(
             tags.stream()
                 .map((tag) -> tag == null ? "null" : "\"" + tag + "\"")
@@ -110,11 +118,12 @@ public class PersonUtil {
      * @param phone the string representation of the {@code Person}'s phone number
      * @param address the string representation of the {@code Person}'s address
      * @param email the string representation of the {@code Person}'s email address
+     * @param rate the string representation of the {@code Person}'s rate
      * @param tags the string representation of the tags assigned to the {@code Person}
      * @return a JSON serialization of the given {@code Person}
      */
     public static String serializePerson(String personId, String name, String phone, String address, String email,
-            String tags) {
+                String rate, String tags) {
         Map<String, String> map = new LinkedHashMap<>();
 
         map.put("id", personId == null ? "null" : "\"" + personId + "\"");
@@ -122,8 +131,12 @@ public class PersonUtil {
         map.put("phone", phone == null ? "null" : "\"" + phone + "\"");
         map.put("email", email == null ? "null" : "\"" + email + "\"");
         map.put("address", address == null ? "null" : "\"" + address + "\"");
+        map.put("rate", rate == null ? "null" : "{\n  \"amount\" : \"" + rate + "\",\n  \"duration\""
+                + " : \"PT1H\"\n}");
         map.put("tagged", tags);
 
-        return TestUtil.serializeObject(map);
+        String res = TestUtil.serializeObject(map);
+        System.out.println(res);
+        return res;
     }
 }

--- a/src/test/java/peoplesoft/testutil/TypicalPersons.java
+++ b/src/test/java/peoplesoft/testutil/TypicalPersons.java
@@ -8,6 +8,8 @@ import static peoplesoft.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static peoplesoft.logic.commands.CommandTestUtil.VALID_RATE_AMY;
+import static peoplesoft.logic.commands.CommandTestUtil.VALID_RATE_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
 import static peoplesoft.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
@@ -25,35 +27,37 @@ public class TypicalPersons {
 
     public static final Person ALICE = new PersonBuilder().withName("Alice Pauline")
             .withAddress("123, Jurong West Ave 6, #08-111").withEmail("alice@example.com")
-            .withPhone("94351253")
+            .withPhone("94351253").withRate(30.2)
             .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
-            .withAddress("311, Clementi Ave 2, #02-25")
+            .withAddress("311, Clementi Ave 2, #02-25").withRate(10.8)
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends").build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
-            .withEmail("heinz@example.com").withAddress("wall street").build();
+            .withEmail("heinz@example.com").withAddress("wall street").withRate(40).build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
-            .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends").build();
+            .withEmail("cornelia@example.com").withAddress("10th street").withRate(60)
+            .withTags("friends").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").build();
+            .withEmail("werner@example.com").withAddress("michegan ave").withRate(108.6).build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
-            .withEmail("lydia@example.com").withAddress("little tokyo").build();
+            .withEmail("lydia@example.com").withAddress("little tokyo").withRate(42.7624).build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").build();
+            .withEmail("anna@example.com").withAddress("4th street").withRate(64.314159265).build();
 
     // Manually added
     public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
-            .withEmail("stefan@example.com").withAddress("little india").build();
+            .withEmail("stefan@example.com").withAddress("little india").withRate(10).build();
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
-            .withEmail("hans@example.com").withAddress("chicago ave").build();
+            .withEmail("hans@example.com").withAddress("chicago ave").withRate(20.2).build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
-            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();
+            .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withRate(VALID_RATE_AMY)
+            .withTags(VALID_TAG_FRIEND).build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
-            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
-            .build();
+            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withRate(VALID_RATE_BOB)
+            .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER
 


### PR DESCRIPTION
`Person` now has an associated `Rate` attribute to denote the base pay of an individual. Updated `AddCommand` to include rate as an argument too.

Also updated the relevant tests which involved `Person` (of which there were many).

Also fixes a bug with `JobListCommand` to now display the full unfiltered list.

Closes #98.