### PR TITLE
Updated `Employment` to support many-to-many relationships

### DIFF
--- a/data.example/addressbook.json
+++ b/data.example/addressbook.json
@@ -58,5 +58,5 @@
   "jobs" : [ ],
   "employment" : { },
   "jobIdState" : 0,
-  "personIdState" : 0
+  "personIdState" : 5
 }

--- a/src/main/java/peoplesoft/logic/commands/ClearCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/ClearCommand.java
@@ -6,7 +6,7 @@ import peoplesoft.commons.core.JobIdFactory;
 import peoplesoft.commons.core.PersonIdFactory;
 import peoplesoft.model.AddressBook;
 import peoplesoft.model.Model;
-import peoplesoft.model.util.Employment;
+import peoplesoft.model.employment.Employment;
 
 /**
  * Clears the address book.

--- a/src/main/java/peoplesoft/logic/commands/DeleteCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/DeleteCommand.java
@@ -8,8 +8,8 @@ import peoplesoft.commons.core.Messages;
 import peoplesoft.commons.core.index.Index;
 import peoplesoft.logic.commands.exceptions.CommandException;
 import peoplesoft.model.Model;
+import peoplesoft.model.employment.Employment;
 import peoplesoft.model.person.Person;
-import peoplesoft.model.util.Employment;
 
 /**
  * Deletes a person identified using it's displayed index from the database.

--- a/src/main/java/peoplesoft/logic/commands/EditCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/EditCommand.java
@@ -20,6 +20,7 @@ import peoplesoft.commons.core.index.Index;
 import peoplesoft.commons.util.CollectionUtil;
 import peoplesoft.logic.commands.exceptions.CommandException;
 import peoplesoft.model.Model;
+import peoplesoft.model.employment.Employment;
 import peoplesoft.model.job.Rate;
 import peoplesoft.model.person.Address;
 import peoplesoft.model.person.Email;
@@ -27,7 +28,6 @@ import peoplesoft.model.person.Name;
 import peoplesoft.model.person.Person;
 import peoplesoft.model.person.Phone;
 import peoplesoft.model.tag.Tag;
-import peoplesoft.model.util.Employment;
 
 /**
  * Edits the details of an existing person in the database.

--- a/src/main/java/peoplesoft/logic/commands/EditCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/EditCommand.java
@@ -20,7 +20,6 @@ import peoplesoft.commons.core.index.Index;
 import peoplesoft.commons.util.CollectionUtil;
 import peoplesoft.logic.commands.exceptions.CommandException;
 import peoplesoft.model.Model;
-import peoplesoft.model.employment.Employment;
 import peoplesoft.model.job.Rate;
 import peoplesoft.model.person.Address;
 import peoplesoft.model.person.Email;
@@ -87,8 +86,6 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        // Replaces employment associations
-        Employment.getInstance().editPerson(personToEdit, editedPerson);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
@@ -16,9 +16,10 @@ import peoplesoft.logic.parser.ParserUtil;
 import peoplesoft.logic.parser.exceptions.ParseException;
 import peoplesoft.logic.parser.job.JobAssignCommandParser;
 import peoplesoft.model.Model;
+import peoplesoft.model.employment.Employment;
+import peoplesoft.model.employment.exceptions.DuplicateEmploymentException;
 import peoplesoft.model.job.Job;
 import peoplesoft.model.person.Person;
-import peoplesoft.model.util.Employment;
 import peoplesoft.model.util.ID;
 
 /**
@@ -36,6 +37,7 @@ public class JobAssignCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Assigned Job %s to %s\n%s has the following jobs: %s";
     public static final String MESSAGE_JOB_NOT_FOUND = "This job does not exist";
+    public static final String MESSAGE_DUPLICATE_EMPLOYMENT = "This person is already assigned to this job";
 
     private ID jobId;
     private Index personIndex;
@@ -87,6 +89,8 @@ public class JobAssignCommand extends Command {
         } catch (IndexOutOfBoundsException e) {
             // Asserts that filtered list should always contain exactly the filtered element
             assert false;
+        } catch (DuplicateEmploymentException e) {
+            throw new CommandException(MESSAGE_DUPLICATE_EMPLOYMENT);
         }
 
         List<Job> jobs = Employment.getInstance().getJobs(person, model);

--- a/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
@@ -10,10 +10,10 @@ import peoplesoft.logic.commands.exceptions.CommandException;
 import peoplesoft.logic.parser.exceptions.ParseException;
 import peoplesoft.logic.parser.job.JobDeleteCommandParser;
 import peoplesoft.model.Model;
+import peoplesoft.model.employment.Employment;
 import peoplesoft.model.job.Job;
 import peoplesoft.model.job.Money;
 import peoplesoft.model.job.Rate;
-import peoplesoft.model.util.Employment;
 import peoplesoft.model.util.ID;
 
 /**

--- a/src/main/java/peoplesoft/logic/commands/job/JobListCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobListCommand.java
@@ -6,7 +6,7 @@ import peoplesoft.logic.commands.Command;
 import peoplesoft.logic.commands.CommandResult;
 import peoplesoft.logic.commands.exceptions.CommandException;
 import peoplesoft.model.Model;
-import peoplesoft.model.util.Employment;
+import peoplesoft.model.employment.Employment;
 
 /**
  * Lists the {@code Jobs} stored in {@code AddressBook}.

--- a/src/main/java/peoplesoft/model/AddressBook.java
+++ b/src/main/java/peoplesoft/model/AddressBook.java
@@ -26,6 +26,7 @@ import javafx.collections.ObservableList;
 import peoplesoft.commons.core.JobIdFactory;
 import peoplesoft.commons.core.PersonIdFactory;
 import peoplesoft.commons.util.JsonUtil;
+import peoplesoft.model.employment.Employment;
 import peoplesoft.model.job.Job;
 import peoplesoft.model.job.JobList;
 import peoplesoft.model.job.UniqueJobList;
@@ -33,7 +34,6 @@ import peoplesoft.model.job.exceptions.JobNotFoundException;
 import peoplesoft.model.person.Person;
 import peoplesoft.model.person.UniquePersonList;
 import peoplesoft.model.person.exceptions.PersonNotFoundException;
-import peoplesoft.model.util.Employment;
 import peoplesoft.model.util.ID;
 
 /**

--- a/src/main/java/peoplesoft/model/employment/Employment.java
+++ b/src/main/java/peoplesoft/model/employment/Employment.java
@@ -62,9 +62,12 @@ public class Employment {
      *
      * @param map Map of values
      */
-    public Employment(Map<ID, Set<ID>> map) {
+    Employment(Map<ID, Set<ID>> map) {
         requireNonNull(map);
-        this.map = map;
+        this.map = new HashMap<>();
+        for (Map.Entry<ID, Set<ID>> e : map.entrySet()) {
+            this.map.put(e.getKey(), new TreeSet<>(e.getValue()));
+        }
     }
 
     /**
@@ -144,8 +147,8 @@ public class Employment {
         requireAllNonNull(person, model);
 
         // TODO: Updates UI, remove if not needed
-        model.updateFilteredJobList(job -> map.get(job.getJobId()) == null
-                ? false : map.get(job.getJobId()).contains(person.getPersonId()));
+        model.updateFilteredJobList(job -> map.get(job.getJobId()) != null
+                && map.get(job.getJobId()).contains(person.getPersonId()));
         return model.getFilteredJobList();
     }
 

--- a/src/main/java/peoplesoft/model/employment/exceptions/DuplicateEmploymentException.java
+++ b/src/main/java/peoplesoft/model/employment/exceptions/DuplicateEmploymentException.java
@@ -1,0 +1,4 @@
+package peoplesoft.model.employment.exceptions;
+
+public class DuplicateEmploymentException extends RuntimeException {
+}

--- a/src/main/java/peoplesoft/model/employment/exceptions/EmploymentNotFoundException.java
+++ b/src/main/java/peoplesoft/model/employment/exceptions/EmploymentNotFoundException.java
@@ -1,0 +1,4 @@
+package peoplesoft.model.employment.exceptions;
+
+public class EmploymentNotFoundException extends RuntimeException {
+}

--- a/src/main/java/peoplesoft/model/util/ID.java
+++ b/src/main/java/peoplesoft/model/util/ID.java
@@ -26,7 +26,7 @@ import peoplesoft.commons.util.JsonUtil;
  */
 @JsonSerialize(using = ID.IdSerializer.class)
 @JsonDeserialize(using = ID.IdDeserializer.class)
-public class ID {
+public class ID implements Comparable<ID> {
     public static final String MESSAGE_CONSTRAINTS =
             "IDs should only begin and end with alphanumeric characters, "
             + "contain alphanumeric characters and hyphens, "
@@ -84,6 +84,11 @@ public class ID {
     @Override
     public int hashCode() {
         return value.hashCode();
+    }
+
+    @Override
+    public int compareTo(ID o) {
+        return value.compareTo(o.value);
     }
 
     protected static class IdSerializer extends StdSerializer<ID> {

--- a/src/test/java/peoplesoft/model/AddressBookSerdesTest.java
+++ b/src/test/java/peoplesoft/model/AddressBookSerdesTest.java
@@ -30,9 +30,9 @@ import com.fasterxml.jackson.databind.JsonMappingException;
 import peoplesoft.commons.core.JobIdFactory;
 import peoplesoft.commons.core.PersonIdFactory;
 import peoplesoft.commons.util.JsonUtil;
+import peoplesoft.model.employment.Employment;
 import peoplesoft.model.job.Job;
 import peoplesoft.model.person.Person;
-import peoplesoft.model.util.Employment;
 
 public class AddressBookSerdesTest {
     @Test

--- a/src/test/java/peoplesoft/model/employment/EmploymentTest.java
+++ b/src/test/java/peoplesoft/model/employment/EmploymentTest.java
@@ -1,0 +1,179 @@
+package peoplesoft.model.employment;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static peoplesoft.testutil.Assert.assertThrows;
+import static peoplesoft.testutil.TypicalPersons.ALICE;
+import static peoplesoft.testutil.TypicalPersons.BOB;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import peoplesoft.model.employment.exceptions.DuplicateEmploymentException;
+import peoplesoft.model.employment.exceptions.EmploymentNotFoundException;
+import peoplesoft.model.job.Job;
+import peoplesoft.model.job.Money;
+import peoplesoft.model.job.Rate;
+import peoplesoft.model.util.ID;
+
+public class EmploymentTest {
+    private static final Job EATING = new Job(new ID(1043), "Eating",
+        new Rate(new Money(5.5), Duration.ofHours(1)), Duration.ofDays(1), false);
+    private static final Job RUNNING = new Job(new ID(3175), "Running",
+        new Rate(new Money(6), Duration.ofHours(4)), Duration.ofHours(8), true);
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Employment(null));
+    }
+
+    @Test
+    public void associate_null_throwsNullPointerException() {
+        // null job
+        assertThrows(NullPointerException.class, () -> new Employment().associate(null, ALICE));
+
+        // null person
+        assertThrows(NullPointerException.class, () -> new Employment().associate(EATING, null));
+    }
+
+    @Test
+    public void associate_withoutDuplicates_success() {
+        Employment employment = new Employment();
+
+        // Associate one person to a job
+        employment.associate(EATING, ALICE);
+        assertTrue(employment.getAllJobs().containsKey(EATING.getJobId()));
+        assertTrue(employment.getAllJobs().get(EATING.getJobId()).contains(ALICE.getPersonId()));
+
+        // Associate another person to the same job
+        employment.associate(EATING, BOB);
+        assertTrue(employment.getAllJobs().get(EATING.getJobId()).contains(BOB.getPersonId()));
+
+        // Associate an associated person to another job
+        employment.associate(RUNNING, ALICE);
+        assertTrue(employment.getAllJobs().containsKey(RUNNING.getJobId()));
+        assertTrue(employment.getAllJobs().get(RUNNING.getJobId()).contains(ALICE.getPersonId()));
+
+        // No association when not associated
+        assertFalse(employment.getAllJobs().get(RUNNING.getJobId()).contains(BOB.getPersonId()));
+    }
+
+    @Test
+    public void associate_duplicateEmployment_throwsDuplicateEmploymentException() {
+        Employment employment = new Employment();
+        employment.associate(EATING, ALICE);
+        assertThrows(DuplicateEmploymentException.class, () -> employment.associate(EATING, ALICE));
+    }
+
+    @Test
+    public void disassociate_null_throwsNullPointerException() {
+        // null job
+        assertThrows(NullPointerException.class, () -> new Employment().disassociate(null, ALICE));
+
+        // null person
+        assertThrows(NullPointerException.class, () -> new Employment().disassociate(EATING, null));
+    }
+
+    @Test
+    public void disassociate_employmentExists_success() {
+        Employment employment = new Employment();
+        employment.associate(EATING, ALICE);
+        employment.associate(EATING, BOB);
+        employment.associate(RUNNING, ALICE);
+
+        // Disassociate two jobs to same person
+        employment.disassociate(RUNNING, ALICE);
+        assertFalse(employment.getAllJobs().containsKey(RUNNING.getJobId()));
+
+        // Disassociate same job to two people
+        employment.disassociate(EATING, BOB);
+        assertTrue(employment.getAllJobs().containsKey(EATING.getJobId()));
+        assertTrue(employment.getAllJobs().get(EATING.getJobId()).contains(ALICE.getPersonId()));
+        assertFalse(employment.getAllJobs().get(EATING.getJobId()).contains(BOB.getPersonId()));
+
+        // Disassociate one job to one person
+        employment.disassociate(EATING, ALICE);
+        assertFalse(employment.getAllJobs().containsKey(EATING.getJobId()));
+    }
+
+    @Test
+    public void disassociate_employmentMissing_throwsEmploymentNotFoundException() {
+        Employment employment = new Employment();
+        employment.associate(EATING, ALICE);
+
+        // Job missing
+        assertThrows(EmploymentNotFoundException.class, () -> employment.disassociate(RUNNING, ALICE));
+
+        // Person missing
+        assertThrows(EmploymentNotFoundException.class, () -> employment.disassociate(EATING, BOB));
+    }
+
+    @Test
+    public void deletePerson_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Employment().deletePerson(null));
+    }
+
+    @Test
+    public void deletePerson_success() {
+        Employment employment = new Employment();
+        employment.associate(EATING, ALICE);
+        employment.associate(EATING, BOB);
+        employment.associate(RUNNING, ALICE);
+
+        // Delete Bob
+        employment.deletePerson(BOB);
+        assertTrue(employment.getAllJobs().containsKey(EATING.getJobId()));
+        assertTrue(employment.getAllJobs().get(EATING.getJobId()).contains(ALICE.getPersonId()));
+        assertFalse(employment.getAllJobs().get(EATING.getJobId()).contains(BOB.getPersonId()));
+
+        // Delete Alice
+        employment.deletePerson(ALICE);
+        assertFalse(employment.getAllJobs().containsKey(EATING.getJobId()));
+        assertFalse(employment.getAllJobs().containsKey(RUNNING.getJobId()));
+    }
+
+    @Test
+    public void editPerson_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Employment().editPerson(null, ALICE));
+        assertThrows(NullPointerException.class, () -> new Employment().editPerson(ALICE, null));
+    }
+
+    @Test
+    public void editPerson_success() {
+        Employment employment = new Employment();
+        employment.associate(EATING, ALICE);
+        employment.associate(RUNNING, ALICE);
+
+        // Edit Alice to Bob
+        employment.editPerson(ALICE, BOB);
+        assertTrue(employment.getAllJobs().containsKey(EATING.getJobId()));
+        assertFalse(employment.getAllJobs().get(EATING.getJobId()).contains(ALICE.getPersonId()));
+        assertTrue(employment.getAllJobs().get(EATING.getJobId()).contains(BOB.getPersonId()));
+        assertTrue(employment.getAllJobs().containsKey(RUNNING.getJobId()));
+        assertFalse(employment.getAllJobs().get(RUNNING.getJobId()).contains(ALICE.getPersonId()));
+        assertTrue(employment.getAllJobs().get(RUNNING.getJobId()).contains(BOB.getPersonId()));
+    }
+
+    @Test
+    public void deleteJob_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Employment().deleteJob(null));
+    }
+
+    @Test
+    public void deleteJob_success() {
+        Employment employment = new Employment();
+        employment.associate(EATING, ALICE);
+        employment.associate(EATING, BOB);
+        employment.associate(RUNNING, ALICE);
+
+        // Delete eating
+        employment.deleteJob(EATING);
+        assertFalse(employment.getAllJobs().containsKey(EATING.getJobId()));
+        assertTrue(employment.getAllJobs().containsKey(RUNNING.getJobId()));
+
+        // Delete Alice
+        employment.deleteJob(RUNNING);
+        assertFalse(employment.getAllJobs().containsKey(RUNNING));
+    }
+}

--- a/src/test/java/peoplesoft/model/employment/EmploymentTest.java
+++ b/src/test/java/peoplesoft/model/employment/EmploymentTest.java
@@ -41,21 +41,21 @@ public class EmploymentTest {
     public void associate_withoutDuplicates_success() {
         Employment employment = new Employment();
 
-        // Associate one person to a job
+        // Associate eating to Alice
         employment.associate(EATING, ALICE);
         assertTrue(employment.getAllJobs().containsKey(EATING.getJobId()));
         assertTrue(employment.getAllJobs().get(EATING.getJobId()).contains(ALICE.getPersonId()));
 
-        // Associate another person to the same job
+        // Associate eating to Bob
         employment.associate(EATING, BOB);
         assertTrue(employment.getAllJobs().get(EATING.getJobId()).contains(BOB.getPersonId()));
 
-        // Associate an associated person to another job
+        // Associate running to Alice
         employment.associate(RUNNING, ALICE);
         assertTrue(employment.getAllJobs().containsKey(RUNNING.getJobId()));
         assertTrue(employment.getAllJobs().get(RUNNING.getJobId()).contains(ALICE.getPersonId()));
 
-        // No association when not associated
+        // Running is not associated to Bob
         assertFalse(employment.getAllJobs().get(RUNNING.getJobId()).contains(BOB.getPersonId()));
     }
 
@@ -82,17 +82,17 @@ public class EmploymentTest {
         employment.associate(EATING, BOB);
         employment.associate(RUNNING, ALICE);
 
-        // Disassociate two jobs to same person
+        // Disassociate running from Alice
         employment.disassociate(RUNNING, ALICE);
         assertFalse(employment.getAllJobs().containsKey(RUNNING.getJobId()));
 
-        // Disassociate same job to two people
+        // Disassociate eating from Bob
         employment.disassociate(EATING, BOB);
         assertTrue(employment.getAllJobs().containsKey(EATING.getJobId()));
         assertTrue(employment.getAllJobs().get(EATING.getJobId()).contains(ALICE.getPersonId()));
         assertFalse(employment.getAllJobs().get(EATING.getJobId()).contains(BOB.getPersonId()));
 
-        // Disassociate one job to one person
+        // Disassociate eating from Alice
         employment.disassociate(EATING, ALICE);
         assertFalse(employment.getAllJobs().containsKey(EATING.getJobId()));
     }
@@ -134,28 +134,6 @@ public class EmploymentTest {
     }
 
     @Test
-    public void editPerson_null_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new Employment().editPerson(null, ALICE));
-        assertThrows(NullPointerException.class, () -> new Employment().editPerson(ALICE, null));
-    }
-
-    @Test
-    public void editPerson_success() {
-        Employment employment = new Employment();
-        employment.associate(EATING, ALICE);
-        employment.associate(RUNNING, ALICE);
-
-        // Edit Alice to Bob
-        employment.editPerson(ALICE, BOB);
-        assertTrue(employment.getAllJobs().containsKey(EATING.getJobId()));
-        assertFalse(employment.getAllJobs().get(EATING.getJobId()).contains(ALICE.getPersonId()));
-        assertTrue(employment.getAllJobs().get(EATING.getJobId()).contains(BOB.getPersonId()));
-        assertTrue(employment.getAllJobs().containsKey(RUNNING.getJobId()));
-        assertFalse(employment.getAllJobs().get(RUNNING.getJobId()).contains(ALICE.getPersonId()));
-        assertTrue(employment.getAllJobs().get(RUNNING.getJobId()).contains(BOB.getPersonId()));
-    }
-
-    @Test
     public void deleteJob_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> new Employment().deleteJob(null));
     }
@@ -172,7 +150,7 @@ public class EmploymentTest {
         assertFalse(employment.getAllJobs().containsKey(EATING.getJobId()));
         assertTrue(employment.getAllJobs().containsKey(RUNNING.getJobId()));
 
-        // Delete Alice
+        // Delete running
         employment.deleteJob(RUNNING);
         assertFalse(employment.getAllJobs().containsKey(RUNNING));
     }


### PR DESCRIPTION
Along with this, a future implementation of a command for unassigning `Jobs` from `Persons` may be needed.

Closes #104.