### PR TITLE
Change markdown parser for Jekyll

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,7 +6,7 @@ header_pages:
   - DeveloperGuide.md
   - AboutUs.md
 
-markdown: kramdown
+markdown: GFM
 
 repository: "AY2122S2-CS2103T-T11-3/tp"
 github_icon: "images/github-icon.png"


### PR DESCRIPTION
Unreadable command summary may be due to bad parsing with kramdown

Potentially fixes #143