### PR TITLE
Add base pay to people, make base pay and durations reader-friendly

### DIFF
--- a/src/main/java/peoplesoft/model/money/Rate.java
+++ b/src/main/java/peoplesoft/model/money/Rate.java
@@ -6,6 +6,8 @@ import static peoplesoft.model.job.util.MoneyUtil.requireNonNegative;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.text.DecimalFormat;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.Objects;
@@ -103,8 +105,20 @@ public class Rate {
      */
     @Override
     public String toString() {
-        // TODO make it more user friendly, e.g. $5 / hour
-        return String.format("%s / %dH", amount, duration.toHours());
+        BigDecimal value = amount.getValue();
+        float hours = duration.toHours();
+        BigDecimal perHour = value.divide(BigDecimal.valueOf(hours), RoundingMode.HALF_UP);
+
+        // @@author Sergey Vyacheslavovich Brunov for converting big decimal to 2dp
+        // retrieved from https://stackoverflow.com/a/10457320/16777554
+        DecimalFormat df = new DecimalFormat();
+        df.setMaximumFractionDigits(2);
+        df.setMinimumFractionDigits(0);
+        df.setGroupingUsed(false);
+
+        String result = df.format(perHour);
+
+        return String.format("$%s/h", result);
     }
 
     protected static class RateSerializer extends StdSerializer<Rate> {

--- a/src/main/java/peoplesoft/ui/regions/JobCard.java
+++ b/src/main/java/peoplesoft/ui/regions/JobCard.java
@@ -54,7 +54,7 @@ public class JobCard extends UiPart<Region> {
         this.job = job;
         idx.setText(displayedIndex + "");
         desc.setText(job.getDesc());
-        duration.setText(job.getDuration().toString());
+        duration.setText(job.getDuration().toHours() + "h");
         doneIcon.setImage(job.hasPaid() ? tick : cross);
         paidForIcon.setImage(job.isFinal() ? tick : cross);
 

--- a/src/main/java/peoplesoft/ui/regions/JobCard.java
+++ b/src/main/java/peoplesoft/ui/regions/JobCard.java
@@ -53,15 +53,15 @@ public class JobCard extends UiPart<Region> {
         super(FXML);
 
         // calculate time
-        int HH = job.getDuration().toHoursPart();
+        int hH = job.getDuration().toHoursPart();
         int mins = job.getDuration().toMinutesPart();
-        String MM = mins == 0 ? "" : (mins + "m");
+        String mM = mins == 0 ? "" : (mins + "m");
 
         // assign values
         this.job = job;
         idx.setText(displayedIndex + "");
         desc.setText(job.getDesc());
-        duration.setText(String.format("%dh%s", HH, MM));
+        duration.setText(String.format("%dh%s", hH, mM));
         doneIcon.setImage(job.hasPaid() ? tick : cross);
         paidForIcon.setImage(job.isFinal() ? tick : cross);
 

--- a/src/main/java/peoplesoft/ui/regions/JobCard.java
+++ b/src/main/java/peoplesoft/ui/regions/JobCard.java
@@ -61,7 +61,7 @@ public class JobCard extends UiPart<Region> {
         this.job = job;
         idx.setText(displayedIndex + "");
         desc.setText(job.getDesc());
-        duration.setText(String.format("%dh%s", hH, mM));
+        duration.setText(String.format("%dh %s", hH, mM));
         doneIcon.setImage(job.hasPaid() ? tick : cross);
         paidForIcon.setImage(job.isFinal() ? tick : cross);
 

--- a/src/main/java/peoplesoft/ui/regions/JobCard.java
+++ b/src/main/java/peoplesoft/ui/regions/JobCard.java
@@ -51,10 +51,17 @@ public class JobCard extends UiPart<Region> {
      */
     public JobCard(Job job, int displayedIndex) {
         super(FXML);
+
+        // calculate time
+        int HH = job.getDuration().toHoursPart();
+        int mins = job.getDuration().toMinutesPart();
+        String MM = mins == 0 ? "" : (mins + "m");
+
+        // assign values
         this.job = job;
         idx.setText(displayedIndex + "");
         desc.setText(job.getDesc());
-        duration.setText(job.getDuration().toHours() + "h");
+        duration.setText(String.format("%dh%s", HH, MM));
         doneIcon.setImage(job.hasPaid() ? tick : cross);
         paidForIcon.setImage(job.isFinal() ? tick : cross);
 

--- a/src/main/java/peoplesoft/ui/regions/PersonCard.java
+++ b/src/main/java/peoplesoft/ui/regions/PersonCard.java
@@ -32,6 +32,8 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label phone;
     @FXML
+    private Label basePay;
+    @FXML
     private Label email;
     @FXML
     private Label address;
@@ -45,6 +47,7 @@ public class PersonCard extends UiPart<Region> {
         idx.setText(displayedIndex + "");
         name.setText(person.getName().fullName);
         amtDue.setText(person.getAmountDue().toString());
+        basePay.setText(person.getRate().toString());
         phone.setText(person.getPhone().value);
         email.setText(person.getEmail().value);
         address.setText(person.getAddress().value);

--- a/src/main/resources/view/JobListCard.fxml
+++ b/src/main/resources/view/JobListCard.fxml
@@ -12,7 +12,7 @@
       <Label fx:id="idx" minWidth="17.0" prefHeight="17.0" prefWidth="17.0" text="1" />
       <Label fx:id="desc" layoutX="35.0" layoutY="27.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="Fix washing machine" wrapText="true" />
       <Label fx:id="duration" layoutX="265.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="PT48H" wrapText="true" />
-      <StackPane alignment="CENTER_LEFT" maxWidth="80.0" minWidth="80.0" prefWidth="80.0">
+      <StackPane alignment="CENTER_LEFT" maxWidth="30.0" minWidth="30.0" prefWidth="30.0">
          <children>
             <ImageView fx:id="doneIcon" fitHeight="16.0" fitWidth="16.0" pickOnBounds="true" preserveRatio="true">
                <image>
@@ -21,7 +21,7 @@
             </ImageView>
          </children>
       </StackPane>
-      <StackPane alignment="CENTER_LEFT" maxWidth="80.0" minWidth="80.0" prefWidth="80.0">
+      <StackPane alignment="CENTER_LEFT" maxWidth="30.0" minWidth="30.0" prefWidth="30.0">
          <children>
             <ImageView fx:id="paidForIcon" fitHeight="16.0" fitWidth="16.0" pickOnBounds="true" preserveRatio="true">
                <image>

--- a/src/main/resources/view/JobListCard.fxml
+++ b/src/main/resources/view/JobListCard.fxml
@@ -11,7 +11,7 @@
    <children>
       <Label fx:id="idx" minWidth="17.0" prefHeight="17.0" prefWidth="17.0" text="1" />
       <Label fx:id="desc" layoutX="35.0" layoutY="27.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="Fix washing machine" wrapText="true" />
-      <Label fx:id="duration" layoutX="265.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="PT48H" wrapText="true" />
+      <Label fx:id="duration" layoutX="265.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="14h 30m" wrapText="true" />
       <StackPane alignment="CENTER_LEFT" maxWidth="30.0" minWidth="30.0" prefWidth="30.0">
          <children>
             <ImageView fx:id="doneIcon" fitHeight="16.0" fitWidth="16.0" pickOnBounds="true" preserveRatio="true">

--- a/src/main/resources/view/OverviewPage.fxml
+++ b/src/main/resources/view/OverviewPage.fxml
@@ -9,7 +9,7 @@
    <children>
 
 
-      <VBox fx:id="personList" prefWidth="480.0" styleClass="main-pane"> <!-- bottom personlist -->
+      <VBox fx:id="personList" prefWidth="580.0" styleClass="main-pane"> <!-- bottom personlist -->
          <children>
             <StackPane fx:id="headerSpace" alignment="CENTER_LEFT" focusTraversable="true" minHeight="-Infinity" prefHeight="60.0" style="-fx-background-color: transparent;">
                <children>
@@ -28,8 +28,9 @@
                <children>
                   <Label fx:id="nm" maxHeight="17.0" maxWidth="17.0" minHeight="17.0" minWidth="17.0" prefHeight="17.0" prefWidth="17.0" text="#" textFill="WHITE" />
                   <Label fx:id="name" layoutX="35.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="Name" textFill="WHITE" />
-                  <Label fx:id="name2" layoutX="47.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="Unpaid" textFill="WHITE" />
+                  <Label fx:id="name2" layoutX="47.0" layoutY="27.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="Unpaid" textFill="WHITE" />
                   <Label fx:id="tags" layoutX="35.0" layoutY="27.0" maxWidth="65.0" minWidth="65.0" prefWidth="65.0" text="Tags" textFill="WHITE" />
+                  <Label fx:id="phone2" layoutX="262.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="Base Pay" textFill="WHITE" wrapText="true" />
                   <Label fx:id="phone" layoutX="51.0" layoutY="27.0" maxWidth="70.0" minWidth="70.0" prefWidth="70.0" text="Phone" textFill="WHITE" wrapText="true" />
                   <Label fx:id="email" layoutX="265.0" layoutY="27.0" maxWidth="70.0" minWidth="70.0" prefWidth="70.0" text="Mail" textFill="WHITE" wrapText="true" />
                   <Label fx:id="address" layoutX="337.0" layoutY="27.0" maxWidth="59.0" minWidth="59.0" prefWidth="59.0" text="Address" textFill="WHITE" wrapText="true" />
@@ -42,9 +43,9 @@
             <StackPane fx:id="personListPanelPlaceholder" prefHeight="3000.0" prefWidth="480.0" />
          </children>
       </VBox>
-      <VBox fx:id="personList1" layoutX="40.0" layoutY="40.0" prefWidth="480.0" styleClass="main-pane">
+      <VBox fx:id="personList1" layoutX="40.0" layoutY="40.0" prefWidth="380.0" styleClass="main-pane">
          <children>
-            <StackPane fx:id="commandBoxPlaceholder11" alignment="CENTER_LEFT" focusTraversable="true" minHeight="-Infinity" prefHeight="60.0" style="-fx-background-color: transparent;">
+            <StackPane fx:id="commandBoxPlaceholder11" alignment="CENTER_LEFT" focusTraversable="true" minHeight="-Infinity" prefHeight="60.0" prefWidth="380.0" style="-fx-background-color: transparent;">
                <children>
                   <Label text="Jobs" textFill="WHITE">
                      <font>
@@ -56,20 +57,20 @@
                   <Insets left="20.0" />
                </padding>
             </StackPane>
-            <HBox fx:id="listheader1" alignment="CENTER_LEFT" prefHeight="50.0" prefWidth="480.0" spacing="10.0" style="-fx-background-color: #33344B;">
+            <HBox fx:id="listheader1" alignment="CENTER_LEFT" prefHeight="50.0" prefWidth="380.0" spacing="10.0" style="-fx-background-color: #33344B;">
                <children>
                   <Label fx:id="nm1" minHeight="30.0" minWidth="17.0" prefHeight="30.0" prefWidth="17.0" text="#" textFill="WHITE" />
                   <Label fx:id="name1" layoutX="35.0" layoutY="27.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="Description" textFill="WHITE" />
                   <Label fx:id="phone1" layoutX="51.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="Duration" textFill="WHITE" wrapText="true" />
-                  <Label fx:id="email1" layoutX="265.0" layoutY="27.0" maxWidth="80.0" minWidth="80.0" prefWidth="80.0" text="Done" textFill="WHITE" wrapText="true" />
-                  <Label fx:id="tags1" layoutX="35.0" layoutY="27.0" maxWidth="80.0" minWidth="80.0" prefWidth="80.0" text="Paid" textFill="WHITE" />
+                  <Label fx:id="email1" layoutX="265.0" layoutY="27.0" maxWidth="30.0" minWidth="30.0" prefWidth="30.0" text="Done" textFill="WHITE" wrapText="true" />
+                  <Label fx:id="tags1" layoutX="35.0" layoutY="27.0" maxWidth="30.0" minWidth="30.0" prefWidth="30.0" text="Paid" textFill="WHITE" />
                   <Label fx:id="address1" layoutX="337.0" layoutY="27.0" minWidth="60.0" prefWidth="60.0" text="In Charge" textFill="WHITE" wrapText="true" />
                </children>
                <padding>
                   <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
                </padding>
             </HBox>
-            <StackPane fx:id="jobListPanelPlaceholder" prefHeight="3000.0" prefWidth="990.0" />
+            <StackPane fx:id="jobListPanelPlaceholder" prefHeight="3000.0" prefWidth="380.0" />
          </children>
       </VBox>
    </children>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -8,8 +8,9 @@
    <children>
       <Label fx:id="idx" maxHeight="17.0" maxWidth="17.0" minHeight="17.0" minWidth="17.0" prefHeight="17.0" prefWidth="17.0" text="1" />
       <Label fx:id="name" layoutX="35.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="Nicole Lee Siying Rajara" wrapText="true" />
-      <Label fx:id="amtDue" layoutX="202.0" layoutY="37.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="\$8888.88" wrapText="true" />
+      <Label fx:id="amtDue" layoutX="202.0" layoutY="37.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="\$8888.88" wrapText="true" />
       <FlowPane fx:id="tags" alignment="CENTER_LEFT" maxWidth="65.0" minWidth="65.0" prefWidth="65.0" prefWrapLength="50.0" />
+      <Label fx:id="basePay" layoutX="302.0" layoutY="37.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="\$30 / H" wrapText="true" />
       <Label fx:id="phone" layoutX="51.0" layoutY="27.0" maxWidth="70.0" minWidth="70.0" prefWidth="70.0" text="62353535" wrapText="true" />
       <Label fx:id="email" layoutX="265.0" layoutY="27.0" maxWidth="70.0" minWidth="70.0" prefWidth="70.0" text="nicole@staffhub.org" wrapText="true" />
       <Label fx:id="address" layoutX="337.0" layoutY="27.0" maxWidth="59.0" minWidth="59.0" prefWidth="59.0" text="S888888 1 Tech Drive" wrapText="true" />

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -10,7 +10,7 @@
       <Label fx:id="name" layoutX="35.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="Nicole Lee Siying Rajara" wrapText="true" />
       <Label fx:id="amtDue" layoutX="202.0" layoutY="37.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="\$8888.88" wrapText="true" />
       <FlowPane fx:id="tags" alignment="CENTER_LEFT" maxWidth="65.0" minWidth="65.0" prefWidth="65.0" prefWrapLength="50.0" />
-      <Label fx:id="basePay" layoutX="302.0" layoutY="37.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="\$30 / H" wrapText="true" />
+      <Label fx:id="basePay" layoutX="302.0" layoutY="37.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="\$30/h" wrapText="true" />
       <Label fx:id="phone" layoutX="51.0" layoutY="27.0" maxWidth="70.0" minWidth="70.0" prefWidth="70.0" text="62353535" wrapText="true" />
       <Label fx:id="email" layoutX="265.0" layoutY="27.0" maxWidth="70.0" minWidth="70.0" prefWidth="70.0" text="nicole@staffhub.org" wrapText="true" />
       <Label fx:id="address" layoutX="337.0" layoutY="27.0" maxWidth="59.0" minWidth="59.0" prefWidth="59.0" text="S888888 1 Tech Drive" wrapText="true" />


### PR DESCRIPTION
Let the pictures do the talking :)  

![Screenshot 2022-04-06 at 8 35 55 PM](https://user-images.githubusercontent.com/62384984/161978842-fe0a9389-7627-4e43-a216-399d496f88bd.png)
Rates are now displayed in the form $XX to $XX.XX depending on whether 2dp is needed or not. It is rounded up.

![Screenshot 2022-04-06 at 9 05 39 PM](https://user-images.githubusercontent.com/62384984/161981315-2e419c56-b0e5-49e9-946e-0a97890e3053.png)
Durations are now displayed in the form XXhXXm, rounded up. If the minutes component is not needed, minutes are not displayed.