### PR TITLE
Make ResultDisplay messages more user-friendly

### DIFF
--- a/docs/tutorials/AddRemark.md
+++ b/docs/tutorials/AddRemark.md
@@ -68,7 +68,7 @@ Following the convention in other commands, we add relevant messages as constant
             + ": Edits the remark of the person identified "
             + "by the index number used in the last person listing. "
             + "Existing remark will be overwritten by the input.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Format: INDEX (must be a positive integer) "
             + "r/ [REMARK]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + "r/ Likes to swim.";

--- a/src/main/java/peoplesoft/commons/core/Messages.java
+++ b/src/main/java/peoplesoft/commons/core/Messages.java
@@ -5,15 +5,29 @@ package peoplesoft.commons.core;
  */
 public class Messages {
 
-    // TODO: prefix all with MSG_ instead to make it shorter. and CMD for command, IDX for index
-    public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
-    public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_JOB_DISPLAYED_INDEX = "Invalid index for job";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "Invalid index for person";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_JOBS_LISTED_OVERVIEW = "%1$d jobs listed!";
-    public static final String MESSAGE_MODIFY_FINAL_JOB = "Cannot modify a job that has finalized payment.";
-    public static final String MESSAGE_ASSIGN_PERSON_TO_JOB = "Assign at least one person to this job.";
-    // should add all the command explainers to here also
+    // -- General Commands --
+    public static final String MSG_UNKNOWN_CMD = "Unknown command";
+    public static final String MSG_INVALID_CMD_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MSG_EMPTY_STRING = "A field has been left empty!\nEnter the missing information.";
+    public static final String MSG_DURATION_CONSTRAINTS = "The duration should be a positive number (in hours).";
+    public static final String MSG_DURATION_TOO_LARGE = "The input duration is too long.\n"
+            + "Consider adding the job as two jobs and splitting the duration between them.";
+
+    // -- Person Commands --
+    public static final String MSG_INVALID_PERSON_DISPLAYED_IDX = "Invalid index for person";
+    public static final String MSG_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+
+    // -- Job Commands --
+    public static final String MSG_INVALID_JOB_DISPLAYED_IDX = "The specified job number "
+            + "is not in the displayed list. \nConsider using the JOBLIST command to list all jobs.";
+    public static final String MSG_JOBS_LISTED_OVERVIEW = "%1$d jobs listed!";
+    public static final String MSG_MODIFY_FINAL_JOB = "Cannot modify a job that has been payed.";
+    public static final String MSG_ASSIGN_PERSON_TO_JOB = "Assign at least one person to this job.";
+    public static final String MSG_DUPLICATE_JOB = "This job already exists in the database";
+    public static final String MSG_DUPLICATE_EMPLOYMENT =
+            "%s person(s) have already been assigned to this job.";
+    public static final String MSG_ASSIGN_MARKED_JOB = "Unmark the job before assigning it.";
+    public static final String MSG_JOB_NOT_PAID_FAILURE = // TODO: change message if needed
+            "Payments cannot be finalized if the job is not yet marked as paid.";
 
 }

--- a/src/main/java/peoplesoft/commons/core/Messages.java
+++ b/src/main/java/peoplesoft/commons/core/Messages.java
@@ -7,20 +7,20 @@ public class Messages {
 
     // -- General Commands --
     public static final String MSG_UNKNOWN_CMD = "Unknown command";
-    public static final String MSG_INVALID_CMD_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MSG_EMPTY_STRING = "A field has been left empty!\nEnter the missing information.";
+    public static final String MSG_INVALID_CMD_FORMAT = "Invalid command format. \n%1$s";
+    public static final String MSG_EMPTY_STRING = "A field has been left empty.\nEnter the missing information.";
     public static final String MSG_DURATION_CONSTRAINTS = "The duration should be a positive number (in hours).";
     public static final String MSG_DURATION_TOO_LARGE = "The input duration is too long.\n"
             + "Consider adding the job as two jobs and splitting the duration between them.";
 
     // -- Person Commands --
     public static final String MSG_INVALID_PERSON_DISPLAYED_IDX = "Invalid index for person";
-    public static final String MSG_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MSG_PERSONS_LISTED_OVERVIEW = "%1$d persons listed.";
 
     // -- Job Commands --
     public static final String MSG_INVALID_JOB_DISPLAYED_IDX = "The specified job number "
             + "is not in the displayed list. \nConsider using the JOBLIST command to list all jobs.";
-    public static final String MSG_JOBS_LISTED_OVERVIEW = "%1$d jobs listed!";
+    public static final String MSG_JOBS_LISTED_OVERVIEW = "%1$d jobs listed.";
     public static final String MSG_MODIFY_FINAL_JOB = "Cannot modify a job that has been payed.";
     public static final String MSG_ASSIGN_PERSON_TO_JOB = "Assign at least one person to this job.";
     public static final String MSG_DUPLICATE_JOB = "This job already exists in the database";

--- a/src/main/java/peoplesoft/commons/core/Messages.java
+++ b/src/main/java/peoplesoft/commons/core/Messages.java
@@ -6,7 +6,8 @@ package peoplesoft.commons.core;
 public class Messages {
 
     // -- General Commands --
-    public static final String MSG_UNKNOWN_CMD = "Unknown command";
+    public static final String MSG_UNKNOWN_CMD = "Unknown command.\n"
+            + "Type \"help\" to see a list of available commands.";
     public static final String MSG_INVALID_CMD_FORMAT = "Invalid command format. \n%1$s";
     public static final String MSG_EMPTY_STRING = "A field has been left empty.\nEnter the missing information.";
     public static final String MSG_DURATION_CONSTRAINTS = "The duration should be a positive number (in hours).";
@@ -19,15 +20,17 @@ public class Messages {
 
     // -- Job Commands --
     public static final String MSG_INVALID_JOB_DISPLAYED_IDX = "The specified job number "
-            + "is not in the displayed list. \nConsider using the JOBLIST command to list all jobs.";
+            + "is not in the displayed list. \nConsider using the \"list\" command to list all jobs.";
     public static final String MSG_JOBS_LISTED_OVERVIEW = "%1$d jobs listed.";
-    public static final String MSG_MODIFY_FINAL_JOB = "Cannot modify a job that has been payed.";
+    public static final String MSG_MODIFY_FINAL_JOB = "Cannot modify a job that has been paid.";
     public static final String MSG_ASSIGN_PERSON_TO_JOB = "Assign at least one person to this job.";
     public static final String MSG_DUPLICATE_JOB = "This job already exists in the database";
     public static final String MSG_DUPLICATE_EMPLOYMENT =
-            "%s person(s) have already been assigned to this job.";
+            "%s person(s) have already been assigned to this job.\n"
+            + "Assignments cannot be edited. Please delete this job and create a new one.";
     public static final String MSG_ASSIGN_MARKED_JOB = "Unmark the job before assigning it.";
-    public static final String MSG_JOB_NOT_PAID_FAILURE = // TODO: change message if needed
-            "Payments cannot be finalized if the job is not yet marked as paid.";
+    public static final String MSG_JOB_NOT_PAID_FAILURE =
+            "Payments cannot be finalized if the job is not marked as paid yet.\n"
+            + "Please refer to the user guide for the expected order of actions.";
 
 }

--- a/src/main/java/peoplesoft/logic/commands/ClearCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/ClearCommand.java
@@ -14,7 +14,7 @@ import peoplesoft.model.employment.Employment;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "Employee list has been cleared.";
 
 
     @Override

--- a/src/main/java/peoplesoft/logic/commands/ExitCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting PeopleSoft as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting PeopleSoft as requested...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/peoplesoft/logic/commands/ExitCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting PeopleSoft as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/peoplesoft/logic/commands/ExportCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/ExportCommand.java
@@ -30,7 +30,7 @@ public class ExportCommand extends Command {
     public static final String MESSAGE_EXPORT_PERSON_SUCCESS = "%s's details were "
             + "exported to a .CSV in your data folder using their name. \n"
             + "Now displaying the jobs that they were assigned to.\n"
-            + "use the \"list\" command to see all jobs again.";
+            + "Use the \"list\" command to see all jobs again.";
 
     public static final String MESSAGE_EXPORT_PERSON_FAILURE = "Failed to export "
             + "due to a problem with saving.";

--- a/src/main/java/peoplesoft/logic/commands/ExportCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/ExportCommand.java
@@ -41,7 +41,7 @@ public class ExportCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
         }
 
         Person personToExport = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/peoplesoft/logic/commands/ExportCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/ExportCommand.java
@@ -23,13 +23,16 @@ public class ExportCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Exports a .csv file with the jobs the person worked on, "
             + "including how much pay they should expect to receive.\n"
+            + "All the jobs the person worked on will be displayed under the Jobs list.\n"
             + "Format: " + COMMAND_WORD + " INDEX. \n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_EXPORT_PERSON_SUCCESS = "%s's details were "
-            + "exported to a .CSV in your data folder.";
+            + "exported to a .CSV in your data folder using their name. \n"
+            + "Now displaying the jobs that they were assigned to.\n"
+            + "use the \"list\" command to see all jobs again.";
 
-    public static final String MESSAGE_EXPORT_PERSON_FAILURE = "Failed to Export "
+    public static final String MESSAGE_EXPORT_PERSON_FAILURE = "Failed to export "
             + "due to a problem with saving.";
 
     private final Index targetIndex;
@@ -50,7 +53,7 @@ public class ExportCommand extends Command {
         Person personToExport = lastShownList.get(targetIndex.getZeroBased());
         try {
             Exporter.getNewInstance(personToExport, model).export();
-            return new CommandResult(String.format(MESSAGE_EXPORT_PERSON_SUCCESS, personToExport));
+            return new CommandResult(String.format(MESSAGE_EXPORT_PERSON_SUCCESS, personToExport.getName()));
         } catch (IOException ioException) {
             return new CommandResult(String.format(MESSAGE_EXPORT_PERSON_FAILURE));
         }

--- a/src/main/java/peoplesoft/logic/commands/ExportCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/ExportCommand.java
@@ -23,11 +23,14 @@ public class ExportCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Exports a .csv file with the jobs the person worked on, "
             + "including how much pay they should expect to receive.\n"
-            + "Format: " + COMMAND_WORD + " INDEX. Example: " + COMMAND_WORD + " 1";
+            + "Format: " + COMMAND_WORD + " INDEX. \n"
+            + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_EXPORT_PERSON_SUCCESS = "Exported Person Details: %1$s";
+    public static final String MESSAGE_EXPORT_PERSON_SUCCESS = "%s's details were "
+            + "exported to a .CSV in your data folder.";
 
-    public static final String MESSAGE_EXPORT_PERSON_FAILURE = "Failed to Export due to IO Error";
+    public static final String MESSAGE_EXPORT_PERSON_FAILURE = "Failed to Export "
+            + "due to a problem with saving.";
 
     private final Index targetIndex;
 

--- a/src/main/java/peoplesoft/logic/commands/HelpCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/HelpCommand.java
@@ -12,8 +12,8 @@ public class HelpCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String SHOWING_HELP_MESSAGE = "Opened the help page."
-            + "\n Type any other command to return to the overview page.";
+    public static final String SHOWING_HELP_MESSAGE = "Opened the help page.\n"
+            + "Type any other command to return to the overview page.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/peoplesoft/logic/commands/HelpCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/HelpCommand.java
@@ -12,7 +12,8 @@ public class HelpCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows program usage instructions.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String SHOWING_HELP_MESSAGE = "Opened help window.";
+    public static final String SHOWING_HELP_MESSAGE = "Opened the help page."
+            + "\n Type any other command to return to the overview page.";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_DURATION;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 
+import peoplesoft.commons.core.Messages;
 import peoplesoft.logic.commands.Command;
 import peoplesoft.logic.commands.CommandResult;
 import peoplesoft.logic.commands.exceptions.CommandException;
@@ -19,12 +20,11 @@ public class JobAddCommand extends Command {
     public static final String COMMAND_WORD = "add";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a job to the database. "
-            + "Parameters: "
+            + "Format: "
             + PREFIX_NAME + "NAME "
             + PREFIX_DURATION + "DURATION ";
 
     public static final String MESSAGE_SUCCESS = "New job added: %s";
-    public static final String MESSAGE_DUPLICATE_JOB = "This job already exists in the database";
 
     private final Job toAdd;
 
@@ -43,8 +43,8 @@ public class JobAddCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (model.hasJob(toAdd.getJobId())) {
-            throw new CommandException(MESSAGE_DUPLICATE_JOB);
+        if (model.hasJob(toAdd.getJobId())) { // Note: user will never trigger this error
+            throw new CommandException(Messages.MSG_DUPLICATE_JOB);
         }
 
         model.addJob(toAdd);

--- a/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
@@ -19,11 +19,15 @@ public class JobAddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a job to the database. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a job to the database.\n"
             + "Format: "
             + COMMAND_WORD + " "
             + PREFIX_NAME + "NAME "
-            + PREFIX_DURATION + "DURATION ";
+            + PREFIX_DURATION + "DURATION\n"
+            + "Example: "
+            + COMMAND_WORD + " "
+            + PREFIX_NAME + "Fix washing machine "
+            + PREFIX_DURATION + "2.5\n";
 
     public static final String MESSAGE_SUCCESS = "New job added: %s";
 

--- a/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAddCommand.java
@@ -21,6 +21,7 @@ public class JobAddCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a job to the database. "
             + "Format: "
+            + COMMAND_WORD + " "
             + PREFIX_NAME + "NAME "
             + PREFIX_DURATION + "DURATION ";
 

--- a/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
@@ -26,11 +26,11 @@ public class JobAssignCommand extends Command {
 
     public static final String COMMAND_WORD = "assign";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns a job to one or more person(s). "
-            + "Format: "
-            + COMMAND_WORD + " "
-            + "JOB_INDEX "
-            + PREFIX_INDEX + "PERSON_INDEX [PERSON_INDEX]... (as many persons as needed)";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns a job to one or more person(s).\n"
+            + "Format: " + COMMAND_WORD + " JOB_INDEX "
+            + PREFIX_INDEX + "PERSON_INDEX [PERSON_INDEX]... (as many persons as needed)\n"
+            + "Example: " + COMMAND_WORD + " 2 "
+            + PREFIX_INDEX + "3 " + PREFIX_INDEX + "4";
 
     public static final String MESSAGE_SUCCESS = "Assigned job \"%s\" to %s.";
 

--- a/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
@@ -27,14 +27,11 @@ public class JobAssignCommand extends Command {
     public static final String COMMAND_WORD = "assign";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns a job to one or more person(s). "
-            + "Parameters: "
+            + "Format: "
             + "JOB_INDEX "
-            + PREFIX_INDEX + "PERSON_INDEX [PERSON_INDEX]...";
+            + PREFIX_INDEX + "PERSON_INDEX [PERSON_INDEX]... (as many persons as needed)";
 
-    public static final String MESSAGE_SUCCESS = "Assigned Job %s to %s.";
-    public static final String MESSAGE_DUPLICATE_EMPLOYMENT =
-            "%s person(s) have already been assigned to this job.";
-    public static final String MESSAGE_ASSIGN_MARKED_JOB = "Un-mark the job before assigning it.";
+    public static final String MESSAGE_SUCCESS = "Assigned job \"%s\" to %s.";
 
     private Index jobIndex;
     private Set<Index> personIndexes;
@@ -61,22 +58,22 @@ public class JobAssignCommand extends Command {
         List<Person> lastShownPersons = model.getFilteredPersonList();
 
         if (jobIndex.getZeroBased() >= lastShownJobs.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_JOB_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MSG_INVALID_JOB_DISPLAYED_IDX);
         }
 
         Job job = lastShownJobs.get(jobIndex.getZeroBased());
 
         if (job.isFinal()) {
-            throw new CommandException(Messages.MESSAGE_MODIFY_FINAL_JOB);
+            throw new CommandException(Messages.MSG_MODIFY_FINAL_JOB);
         }
 
         if (job.hasPaid()) {
-            throw new CommandException(MESSAGE_ASSIGN_MARKED_JOB);
+            throw new CommandException(Messages.MSG_ASSIGN_MARKED_JOB);
         }
 
         for (Index i : personIndexes) {
             if (i.getZeroBased() >= lastShownPersons.size()) {
-                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+                throw new CommandException(Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
             }
         }
 
@@ -100,9 +97,9 @@ public class JobAssignCommand extends Command {
 
         if (dupeCount > 0) {
             if (successPersons.isBlank()) {
-                throw new CommandException(String.format(MESSAGE_DUPLICATE_EMPLOYMENT, dupeCount));
+                throw new CommandException(String.format(Messages.MSG_DUPLICATE_EMPLOYMENT, dupeCount));
             } else {
-                throw new CommandException(String.format(MESSAGE_DUPLICATE_EMPLOYMENT, dupeCount) + "\n"
+                throw new CommandException(String.format(Messages.MSG_DUPLICATE_EMPLOYMENT, dupeCount) + "\n"
                         + String.format(MESSAGE_SUCCESS, job.getDesc(), successPersons));
             }
         }

--- a/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobAssignCommand.java
@@ -28,6 +28,7 @@ public class JobAssignCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns a job to one or more person(s). "
             + "Format: "
+            + COMMAND_WORD + " "
             + "JOB_INDEX "
             + PREFIX_INDEX + "PERSON_INDEX [PERSON_INDEX]... (as many persons as needed)";
 

--- a/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
@@ -22,6 +22,7 @@ public class JobDeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the job identified by the index.\n"
+            + "Format: " + COMMAND_WORD + " INDEX\n"
             + "Example: " + COMMAND_WORD + " 3";
 
     public static final String MESSAGE_SUCCESS = "\"%s\" has been deleted.";

--- a/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobDeleteCommand.java
@@ -22,10 +22,9 @@ public class JobDeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the job identified by the index.\n"
-            + "Parameters: JOB_INDEX\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + "Example: " + COMMAND_WORD + " 3";
 
-    public static final String MESSAGE_SUCCESS = "Deleted Job: %s";
+    public static final String MESSAGE_SUCCESS = "\"%s\" has been deleted.";
 
     private final Index toDelete;
 
@@ -45,13 +44,13 @@ public class JobDeleteCommand extends Command {
         List<Job> lastShownList = model.getFilteredJobList();
 
         if (toDelete.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_JOB_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MSG_INVALID_JOB_DISPLAYED_IDX);
         }
 
         Job jobToDelete = lastShownList.get(toDelete.getZeroBased());
 
         if (jobToDelete.isFinal()) {
-            throw new CommandException(Messages.MESSAGE_MODIFY_FINAL_JOB);
+            throw new CommandException(Messages.MSG_MODIFY_FINAL_JOB);
         }
 
         model.deleteJob(jobToDelete);

--- a/src/main/java/peoplesoft/logic/commands/job/JobFinalizeCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobFinalizeCommand.java
@@ -28,7 +28,9 @@ public class JobFinalizeCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Pay out a completed job. Finalizes payments for the job in the job list displayed. "
             + "Note: This command is irreversible!\n"
-            + "Format: JOB_INDEX " + PREFIX_CONFIRMATION + "\n"
+            + "Format: "
+            + COMMAND_WORD + " "
+            + "JOB_INDEX " + PREFIX_CONFIRMATION + "\n"
             + "Example: " + COMMAND_WORD + " 1" + PREFIX_CONFIRMATION;
 
     public static final String MESSAGE_SUCCESS = "Finalized payments for Job %s.";

--- a/src/main/java/peoplesoft/logic/commands/job/JobFinalizeCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobFinalizeCommand.java
@@ -26,11 +26,11 @@ public class JobFinalizeCommand extends Command {
     public static final String COMMAND_WORD = "pay";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Pay out a completed job. Finalizes payments for the job in the job list displayed. "
+            + ": Pay out a completed job. Finalizes payments for the job in the job list displayed.\n"
             + "Note: This command is irreversible!\n"
             + "Format: "
             + COMMAND_WORD + " "
-            + "JOB_INDEX " + PREFIX_CONFIRMATION + "\n"
+            + "INDEX " + PREFIX_CONFIRMATION + "\n"
             + "Example: " + COMMAND_WORD + " 1" + PREFIX_CONFIRMATION;
 
     public static final String MESSAGE_SUCCESS = "Finalized payments for Job %s.";

--- a/src/main/java/peoplesoft/logic/commands/job/JobFinalizeCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobFinalizeCommand.java
@@ -26,15 +26,12 @@ public class JobFinalizeCommand extends Command {
     public static final String COMMAND_WORD = "pay";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Finalizes payments for the job identified by the index number used in the displayed job list.\n"
+            + ": Pay out a completed job. Finalizes payments for the job in the job list displayed. "
             + "Note: This command is irreversible!\n"
-            + "Parameters: JOB_INDEX " + PREFIX_CONFIRMATION + "\n"
+            + "Format: JOB_INDEX " + PREFIX_CONFIRMATION + "\n"
             + "Example: " + COMMAND_WORD + " 1" + PREFIX_CONFIRMATION;
 
     public static final String MESSAGE_SUCCESS = "Finalized payments for Job %s.";
-    public static final String MESSAGE_JOB_NOT_PAID_FAILURE =
-            "Payments cannot be finalized if the job is not yet marked as paid.";
-    // TODO: change message if needed
 
     private final Index toFinalize;
     private Employment instance;
@@ -57,13 +54,13 @@ public class JobFinalizeCommand extends Command {
         List<Job> lastShownList = model.getFilteredJobList();
 
         if (toFinalize.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_JOB_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MSG_INVALID_JOB_DISPLAYED_IDX);
         }
 
         Job job = lastShownList.get(toFinalize.getZeroBased());
 
         if (job.isFinal()) {
-            throw new CommandException(Messages.MESSAGE_MODIFY_FINAL_JOB);
+            throw new CommandException(Messages.MSG_MODIFY_FINAL_JOB);
         }
 
         try {
@@ -71,9 +68,9 @@ public class JobFinalizeCommand extends Command {
             model.setJob(job, finalJob);
             PaymentHandler.finalizePayments(finalJob, model, instance);
         } catch (JobNotPaidException e) {
-            throw new CommandException(MESSAGE_JOB_NOT_PAID_FAILURE, e);
+            throw new CommandException(Messages.MSG_JOB_NOT_PAID_FAILURE, e);
         } catch (PaymentRequiresPersonException e) {
-            throw new CommandException(Messages.MESSAGE_ASSIGN_PERSON_TO_JOB, e);
+            throw new CommandException(Messages.MSG_ASSIGN_PERSON_TO_JOB, e);
         } finally {
             model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         }

--- a/src/main/java/peoplesoft/logic/commands/job/JobFindCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobFindCommand.java
@@ -14,7 +14,9 @@ public class JobFindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all jobs whose description contain all of "
             + "the specified keywords (case-insensitive) and displays them in the list.\n"
-            + "Format: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Format: "
+            + COMMAND_WORD + " "
+            + "KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " electric aircon appliances";
 
     private final JobContainsKeywordsPredicate predicate;

--- a/src/main/java/peoplesoft/logic/commands/job/JobFindCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobFindCommand.java
@@ -12,12 +12,13 @@ public class JobFindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all jobs whose description contain all of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all jobs whose description contains ALL of "
             + "the specified keywords (case-insensitive) and displays them in the list.\n"
             + "Format: "
             + COMMAND_WORD + " "
             + "KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " electric aircon appliances";
+            + "Example: " + COMMAND_WORD + " \"electric aircon appliances\" "
+            + "finds all jobs which have \"electric\", \"aircon\" and \"appliances\" in them.";
 
     private final JobContainsKeywordsPredicate predicate;
 

--- a/src/main/java/peoplesoft/logic/commands/job/JobFindCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobFindCommand.java
@@ -12,9 +12,9 @@ public class JobFindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all jobs whose description contain any of "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all jobs whose description contain all of "
+            + "the specified keywords (case-insensitive) and displays them in the list.\n"
+            + "Format: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " electric aircon appliances";
 
     private final JobContainsKeywordsPredicate predicate;
@@ -28,7 +28,7 @@ public class JobFindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredJobList(predicate);
         return new CommandResult(
-            String.format(Messages.MESSAGE_JOBS_LISTED_OVERVIEW, model.getFilteredJobList().size()));
+            String.format(Messages.MSG_JOBS_LISTED_OVERVIEW, model.getFilteredJobList().size()));
     }
 
     @Override

--- a/src/main/java/peoplesoft/logic/commands/job/JobMarkCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobMarkCommand.java
@@ -25,6 +25,7 @@ public class JobMarkCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Marks the chosen job as completed.\n"
+            + "Format: " + COMMAND_WORD + " INDEX"
             + "Example: " + COMMAND_WORD + " 2";
 
     public static final String MESSAGE_SUCCESS = "Marked job \"%s\" as %s.";

--- a/src/main/java/peoplesoft/logic/commands/job/JobMarkCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/job/JobMarkCommand.java
@@ -24,11 +24,10 @@ public class JobMarkCommand extends Command {
     public static final String COMMAND_WORD = "mark";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Marks the job identified by the index number used in the displayed job list.\n"
-            + "Parameters: JOB_INDEX\n"
-            + "Example: " + COMMAND_WORD + " 1";
+            + ": Marks the chosen job as completed.\n"
+            + "Example: " + COMMAND_WORD + " 2";
 
-    public static final String MESSAGE_SUCCESS = "Marked Job %s as %s";
+    public static final String MESSAGE_SUCCESS = "Marked job \"%s\" as %s.";
 
     private final Index toMark;
     private boolean state;
@@ -52,14 +51,14 @@ public class JobMarkCommand extends Command {
         List<Job> lastShownList = model.getFilteredJobList();
 
         if (toMark.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_JOB_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MSG_INVALID_JOB_DISPLAYED_IDX);
         }
 
         Job jobToMark = lastShownList.get(toMark.getZeroBased());
 
         // Not sure if this should be caught here or later.
         if (jobToMark.isFinal()) {
-            throw new CommandException(Messages.MESSAGE_MODIFY_FINAL_JOB);
+            throw new CommandException(Messages.MSG_MODIFY_FINAL_JOB);
         }
 
         try {
@@ -75,14 +74,14 @@ public class JobMarkCommand extends Command {
                 state = false;
             }
         } catch (PaymentRequiresPersonException e) {
-            throw new CommandException(Messages.MESSAGE_ASSIGN_PERSON_TO_JOB, e);
+            throw new CommandException(Messages.MSG_ASSIGN_PERSON_TO_JOB, e);
         } finally {
             // Turns out model equals() tests filtered lists
             model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
         }
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, jobToMark.getDesc(),
-                state ? "not paid" : "paid"));
+                state ? "Not Paid" : "Paid"));
     }
 
     @Override

--- a/src/main/java/peoplesoft/logic/commands/person/PersonAddCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonAddCommand.java
@@ -23,6 +23,7 @@ public class PersonAddCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the database. "
             + "Format: "
+            + COMMAND_WORD + " "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
@@ -38,7 +39,7 @@ public class PersonAddCommand extends Command {
             + PREFIX_TAG + "Intern "
             + PREFIX_TAG + "Painting";
 
-    public static final String MESSAGE_SUCCESS = "New person added: %1$s";
+    public static final String MESSAGE_SUCCESS = "%s was added.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the database";
 
     private final Person toAdd;
@@ -60,7 +61,7 @@ public class PersonAddCommand extends Command {
         }
 
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getName()));
     }
 
     @Override

--- a/src/main/java/peoplesoft/logic/commands/person/PersonAddCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonAddCommand.java
@@ -22,7 +22,7 @@ public class PersonAddCommand extends Command {
     public static final String COMMAND_WORD = "personadd";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the database. "
-            + "Parameters: "
+            + "Format: "
             + PREFIX_NAME + "NAME "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "

--- a/src/main/java/peoplesoft/logic/commands/person/PersonAddCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonAddCommand.java
@@ -21,7 +21,7 @@ public class PersonAddCommand extends Command {
 
     public static final String COMMAND_WORD = "personadd";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the database. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a person to the database.\n"
             + "Format: "
             + COMMAND_WORD + " "
             + PREFIX_NAME + "NAME "

--- a/src/main/java/peoplesoft/logic/commands/person/PersonDeleteCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonDeleteCommand.java
@@ -22,9 +22,7 @@ public class PersonDeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Format: "
-            + COMMAND_WORD + " "
-            + "PERSON_INDEX (must be a positive integer)\n"
+            + "Format: " + COMMAND_WORD + " INDEX\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "%s was removed.";

--- a/src/main/java/peoplesoft/logic/commands/person/PersonDeleteCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonDeleteCommand.java
@@ -22,10 +22,12 @@ public class PersonDeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Format: PERSON_INDEX (must be a positive integer)\n"
+            + "Format: "
+            + COMMAND_WORD + " "
+            + "PERSON_INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
+    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "%s was removed.";
 
     private final Index targetIndex;
 
@@ -46,7 +48,7 @@ public class PersonDeleteCommand extends Command {
         model.deletePerson(personToDelete);
         // Deletes employment associations
         Employment.getInstance().deletePerson(personToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete.getName()));
     }
 
     @Override

--- a/src/main/java/peoplesoft/logic/commands/person/PersonDeleteCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonDeleteCommand.java
@@ -22,7 +22,7 @@ public class PersonDeleteCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the index number used in the displayed person list.\n"
-            + "Parameters: PERSON_INDEX (must be a positive integer)\n"
+            + "Format: PERSON_INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Person: %1$s";
@@ -39,7 +39,7 @@ public class PersonDeleteCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());

--- a/src/main/java/peoplesoft/logic/commands/person/PersonEditCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonEditCommand.java
@@ -42,10 +42,9 @@ public class PersonEditCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
-            + "Existing values will be overwritten by the input values.\n"
+            + "Existing values and tags will be overwritten by the input values.\n"
             + "Format: "
-            + COMMAND_WORD + " "
-            + "PERSON_INDEX (must be a positive integer) "
+            + COMMAND_WORD + " INDEX "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "

--- a/src/main/java/peoplesoft/logic/commands/person/PersonEditCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonEditCommand.java
@@ -43,7 +43,9 @@ public class PersonEditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Format: PERSON_INDEX (must be a positive integer) "
+            + "Format: "
+            + COMMAND_WORD + " "
+            + "PERSON_INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
@@ -54,7 +56,7 @@ public class PersonEditCommand extends Command {
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
 
-    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
+    public static final String MESSAGE_EDIT_PERSON_SUCCESS = "The details of %s were edited.";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the database.";
 
@@ -91,7 +93,7 @@ public class PersonEditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
+        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson.getName()));
     }
 
     /**

--- a/src/main/java/peoplesoft/logic/commands/person/PersonEditCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonEditCommand.java
@@ -43,7 +43,7 @@ public class PersonEditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: PERSON_INDEX (must be a positive integer) "
+            + "Format: PERSON_INDEX (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
@@ -79,7 +79,7 @@ public class PersonEditCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         if (index.getZeroBased() >= lastShownList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+            throw new CommandException(Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
         }
 
         Person personToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/peoplesoft/logic/commands/person/PersonFindCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonFindCommand.java
@@ -18,7 +18,7 @@ public class PersonFindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Format: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
     private final PersonContainsKeywordsPredicate predicate;
@@ -32,7 +32,7 @@ public class PersonFindCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                String.format(Messages.MSG_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }
 
     @Override

--- a/src/main/java/peoplesoft/logic/commands/person/PersonFindCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonFindCommand.java
@@ -18,7 +18,9 @@ public class PersonFindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Format: KEYWORD [MORE_KEYWORDS]...\n"
+            + "Format: "
+            + COMMAND_WORD + " "
+            + "KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
     private final PersonContainsKeywordsPredicate predicate;

--- a/src/main/java/peoplesoft/logic/commands/person/PersonListCommand.java
+++ b/src/main/java/peoplesoft/logic/commands/person/PersonListCommand.java
@@ -14,7 +14,7 @@ public class PersonListCommand extends Command {
 
     public static final String COMMAND_WORD = "personlist";
 
-    public static final String MESSAGE_SUCCESS = "Listed all persons";
+    public static final String MESSAGE_SUCCESS = "All people are now listed under Employees.";
 
 
     @Override

--- a/src/main/java/peoplesoft/logic/parser/AddressBookParser.java
+++ b/src/main/java/peoplesoft/logic/parser/AddressBookParser.java
@@ -1,7 +1,7 @@
 package peoplesoft.logic.parser;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static peoplesoft.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_UNKNOWN_CMD;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,7 +55,7 @@ public class AddressBookParser {
     public Command parseCommand(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MSG_INVALID_CMD_FORMAT, HelpCommand.MESSAGE_USAGE));
         }
 
         final String commandWord = matcher.group("commandWord");
@@ -113,7 +113,7 @@ public class AddressBookParser {
             return new JobFinalizeCommandParser().parse(arguments);
 
         default:
-            throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+            throw new ParseException(MSG_UNKNOWN_CMD);
         }
     }
 

--- a/src/main/java/peoplesoft/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/DeleteCommandParser.java
@@ -1,0 +1,29 @@
+package peoplesoft.logic.parser;
+
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
+
+import peoplesoft.commons.core.index.Index;
+import peoplesoft.logic.commands.person.PersonDeleteCommand;
+import peoplesoft.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new DeleteCommand object
+ */
+public class DeleteCommandParser implements Parser<PersonDeleteCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteCommand
+     * and returns a DeleteCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public PersonDeleteCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new PersonDeleteCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MSG_INVALID_CMD_FORMAT, PersonDeleteCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+}

--- a/src/main/java/peoplesoft/logic/parser/ExportCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/ExportCommandParser.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 
 import peoplesoft.commons.core.index.Index;
 import peoplesoft.logic.commands.ExportCommand;
@@ -22,7 +22,7 @@ public class ExportCommandParser implements Parser<ExportCommand> {
             return new ExportCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ExportCommand.MESSAGE_USAGE), pe);
+                    String.format(MSG_INVALID_CMD_FORMAT, ExportCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/peoplesoft/logic/parser/ParserUtil.java
+++ b/src/main/java/peoplesoft/logic/parser/ParserUtil.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import peoplesoft.commons.core.Messages;
 import peoplesoft.commons.core.index.Index;
 import peoplesoft.commons.util.StringUtil;
 import peoplesoft.logic.parser.exceptions.ParseException;
@@ -25,9 +26,6 @@ import peoplesoft.model.util.ID;
  * Contains utility methods used for parsing strings in the various *Parser classes.
  */
 public class ParserUtil {
-    public static final String STRING_MESSAGE_CONSTRAINTS = "Empty string not allowed.";
-    public static final String DURATION_MESSAGE_CONSTRAINTS = "Expects a positive number for duration (in hours).";
-    public static final String DURATION_MESSAGE_TOO_LARGE = "Value for duration is too large.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -154,7 +152,7 @@ public class ParserUtil {
         requireNonNull(str);
         String res = str.trim();
         if (res.isBlank()) {
-            throw new ParseException(STRING_MESSAGE_CONSTRAINTS);
+            throw new ParseException(Messages.MSG_EMPTY_STRING);
         }
         return res;
     }
@@ -201,14 +199,14 @@ public class ParserUtil {
         try {
             dur = Double.parseDouble(trim);
         } catch (NumberFormatException e) {
-            throw new ParseException(DURATION_MESSAGE_CONSTRAINTS, e);
+            throw new ParseException(Messages.MSG_DURATION_CONSTRAINTS, e);
         }
         Duration res = Duration.ofMinutes(Math.round(dur * 60));
         if (!isDurationNonNegative(res)) {
-            throw new ParseException(DURATION_MESSAGE_CONSTRAINTS);
+            throw new ParseException(Messages.MSG_DURATION_CONSTRAINTS);
         }
         if (isDurationTooLarge(res)) {
-            throw new ParseException(DURATION_MESSAGE_TOO_LARGE);
+            throw new ParseException(Messages.MSG_DURATION_TOO_LARGE);
         }
         return res;
     }

--- a/src/main/java/peoplesoft/logic/parser/job/JobAddCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobAddCommandParser.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_DURATION;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 
@@ -33,7 +33,7 @@ public class JobAddCommandParser implements Parser<JobAddCommand> {
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_DURATION)
                 || !argMultimap.getPreamble().isBlank()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            throw new ParseException(String.format(MSG_INVALID_CMD_FORMAT,
                     JobAddCommand.MESSAGE_USAGE));
         }
         String name = ParserUtil.parseString(argMultimap.getValue(PREFIX_NAME).get());

--- a/src/main/java/peoplesoft/logic/parser/job/JobAssignCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobAssignCommandParser.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_INDEX;
 
 import java.util.Set;
@@ -30,7 +30,7 @@ public class JobAssignCommandParser implements Parser<JobAssignCommand> {
 
         if (!arePrefixesPresent(argMultimap, PREFIX_INDEX)
                 || argMultimap.getPreamble().isBlank()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            throw new ParseException(String.format(MSG_INVALID_CMD_FORMAT,
                     JobAssignCommand.MESSAGE_USAGE));
         }
         Index jobIndex;
@@ -40,7 +40,7 @@ public class JobAssignCommandParser implements Parser<JobAssignCommand> {
             jobIndex = ParserUtil.parseIndex(argMultimap.getPreamble());
             personIndexes = ParserUtil.parseIndexes(argMultimap.getAllValues(PREFIX_INDEX));
         } catch (ParseException e) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            throw new ParseException(String.format(MSG_INVALID_CMD_FORMAT,
                     JobAssignCommand.MESSAGE_USAGE));
         }
 

--- a/src/main/java/peoplesoft/logic/parser/job/JobDeleteCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobDeleteCommandParser.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 
 import peoplesoft.commons.core.index.Index;
 import peoplesoft.logic.commands.job.JobDeleteCommand;
@@ -23,7 +23,7 @@ public class JobDeleteCommandParser implements Parser<JobDeleteCommand> {
             return new JobDeleteCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, JobDeleteCommand.MESSAGE_USAGE), pe);
+                String.format(MSG_INVALID_CMD_FORMAT, JobDeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 }

--- a/src/main/java/peoplesoft/logic/parser/job/JobFinalizeCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobFinalizeCommandParser.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_CONFIRMATION;
 
 import java.util.stream.Stream;
@@ -29,7 +29,7 @@ public class JobFinalizeCommandParser implements Parser<JobFinalizeCommand> {
 
         if (!arePrefixesPresent(argMultimap, PREFIX_CONFIRMATION) || argMultimap.getPreamble().isBlank()
                 || !argMultimap.getValue(PREFIX_CONFIRMATION).get().isBlank()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            throw new ParseException(String.format(MSG_INVALID_CMD_FORMAT,
                 JobFinalizeCommand.MESSAGE_USAGE));
         }
         try {
@@ -37,7 +37,7 @@ public class JobFinalizeCommandParser implements Parser<JobFinalizeCommand> {
             return new JobFinalizeCommand(index, Employment.getInstance());
         } catch (ParseException pe) {
             throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, JobFinalizeCommand.MESSAGE_USAGE), pe);
+                String.format(MSG_INVALID_CMD_FORMAT, JobFinalizeCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/peoplesoft/logic/parser/job/JobFindCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobFindCommandParser.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 
 import java.util.Arrays;
 
@@ -23,7 +23,7 @@ public class JobFindCommandParser implements Parser<JobFindCommand> {
             trimmedArgs = ParserUtil.parseString(args);
         } catch (ParseException pe) {
             throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, JobFindCommand.MESSAGE_USAGE), pe);
+                String.format(MSG_INVALID_CMD_FORMAT, JobFindCommand.MESSAGE_USAGE), pe);
         }
 
         String[] nameKeywords = trimmedArgs.split("\\s+");

--- a/src/main/java/peoplesoft/logic/parser/job/JobMarkCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/job/JobMarkCommandParser.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 
 import peoplesoft.commons.core.index.Index;
 import peoplesoft.logic.commands.job.JobMarkCommand;
@@ -24,7 +24,7 @@ public class JobMarkCommandParser implements Parser<JobMarkCommand> {
             return new JobMarkCommand(index, Employment.getInstance());
         } catch (ParseException pe) {
             throw new ParseException(
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, JobMarkCommand.MESSAGE_USAGE), pe);
+                String.format(MSG_INVALID_CMD_FORMAT, JobMarkCommand.MESSAGE_USAGE), pe);
         }
     }
 }

--- a/src/main/java/peoplesoft/logic/parser/person/PersonAddCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/person/PersonAddCommandParser.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.person;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
@@ -47,7 +47,7 @@ public class PersonAddCommandParser implements Parser<PersonAddCommand> {
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_RATE)
                 || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonAddCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MSG_INVALID_CMD_FORMAT, PersonAddCommand.MESSAGE_USAGE));
         }
 
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());

--- a/src/main/java/peoplesoft/logic/parser/person/PersonDeleteCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/person/PersonDeleteCommandParser.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.person;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 
 import peoplesoft.commons.core.index.Index;
 import peoplesoft.logic.commands.person.PersonDeleteCommand;
@@ -24,7 +24,7 @@ public class PersonDeleteCommandParser implements Parser<PersonDeleteCommand> {
             return new PersonDeleteCommand(index);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonDeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(MSG_INVALID_CMD_FORMAT , PersonDeleteCommand.MESSAGE_USAGE), pe);
         }
     }
 

--- a/src/main/java/peoplesoft/logic/parser/person/PersonEditCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/person/PersonEditCommandParser.java
@@ -1,7 +1,7 @@
 package peoplesoft.logic.parser.person;
 
 import static java.util.Objects.requireNonNull;
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
@@ -45,7 +45,7 @@ public class PersonEditCommandParser implements Parser<PersonEditCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+            throw new ParseException(String.format(MSG_INVALID_CMD_FORMAT,
                     PersonEditCommand.MESSAGE_USAGE), pe);
         }
 

--- a/src/main/java/peoplesoft/logic/parser/person/PersonFindCommandParser.java
+++ b/src/main/java/peoplesoft/logic/parser/person/PersonFindCommandParser.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.person;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 
 import java.util.Arrays;
 
@@ -26,7 +26,7 @@ public class PersonFindCommandParser implements Parser<PersonFindCommand> {
             trimmedArgs = ParserUtil.parseString(args);
         } catch (ParseException pe) {
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonFindCommand.MESSAGE_USAGE), pe);
+                    String.format(MSG_INVALID_CMD_FORMAT, PersonFindCommand.MESSAGE_USAGE), pe);
         }
 
         String[] nameKeywords = trimmedArgs.split("\\s+");

--- a/src/main/java/peoplesoft/model/money/Rate.java
+++ b/src/main/java/peoplesoft/model/money/Rate.java
@@ -39,7 +39,8 @@ import peoplesoft.model.money.exceptions.NegativeMoneyValueException;
 public class Rate {
     public static final String MESSAGE_CONSTRAINTS = "The rate should not be negative. "
             + "It can include 2 decimal places.";
-    public static final String MESSAGE_TOO_LARGE = "PeopleSoft cannot store such a high rate.";
+    public static final String MESSAGE_TOO_LARGE = "The value for the rate is too large. "
+            + "Are you sure you need to pay this employee more than $1000000 per hour?";
 
     public final Money amount;
     public final Duration duration;

--- a/src/main/java/peoplesoft/model/money/Rate.java
+++ b/src/main/java/peoplesoft/model/money/Rate.java
@@ -37,8 +37,8 @@ import peoplesoft.model.money.exceptions.NegativeMoneyValueException;
 @JsonSerialize(using = Rate.RateSerializer.class)
 @JsonDeserialize(using = Rate.RateDeserializer.class)
 public class Rate {
-    public static final String MESSAGE_CONSTRAINTS = "The rate should not be negative. "
-            + "It can include 2 decimal places.";
+    public static final String MESSAGE_CONSTRAINTS = "The rate should not be negative or "
+            + "have more than 2 decimal places.";
     public static final String MESSAGE_TOO_LARGE = "The value for the rate is too large. "
             + "Are you sure you need to pay this employee more than $1000000 per hour?";
 

--- a/src/main/java/peoplesoft/model/money/Rate.java
+++ b/src/main/java/peoplesoft/model/money/Rate.java
@@ -37,8 +37,9 @@ import peoplesoft.model.money.exceptions.NegativeMoneyValueException;
 @JsonSerialize(using = Rate.RateSerializer.class)
 @JsonDeserialize(using = Rate.RateDeserializer.class)
 public class Rate {
-    public static final String MESSAGE_CONSTRAINTS = "Value for rate should be a non-negative decimal number.";
-    public static final String MESSAGE_TOO_LARGE = "Value for rate is too large.";
+    public static final String MESSAGE_CONSTRAINTS = "The rate should not be negative. "
+            + "It can include 2 decimal places.";
+    public static final String MESSAGE_TOO_LARGE = "PeopleSoft cannot store such a high rate.";
 
     public final Money amount;
     public final Duration duration;

--- a/src/main/java/peoplesoft/model/person/Email.java
+++ b/src/main/java/peoplesoft/model/person/Email.java
@@ -30,11 +30,11 @@ public class Email {
 
     private static final String SPECIAL_CHARACTERS = "+_.-";
     private static final String SPECIAL_CHARACTERS_NO_PERIOD = "+_-";
-    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
+    public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format name@domain "
             + "and adhere to the following constraints:\n"
-            + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
+            + "1. The name should only contain alphanumeric characters and these special characters, excluding "
             + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
-            + "characters.\n"
+            + "characters. Scroll down to read more.\n"
             + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
             + "separated by periods.\n"
             + "The domain name must:\n"

--- a/src/main/resources/styles/DarkTheme.css
+++ b/src/main/resources/styles/DarkTheme.css
@@ -137,11 +137,13 @@
 
 .result-display {
     -fx-background-color: transparent;
+    -fx-border-color: transparent;
     -fx-font-family: "Inter";
     -fx-font-size: 8pt;
 }
 
-.result-display .label {
+.result-display-label {
+    -fx-background-color: pane;
     -fx-text-fill: text-faded !important;
 }
 

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -4,7 +4,7 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
-<ScrollPane fx:id="placeHolder" hbarPolicy="NEVER" minWidth="990.0" prefHeight="73.0" prefWidth="990.0" style="-fx-background-color: transparent;" styleClass="result-display" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
+<ScrollPane fx:id="placeHolder" hbarPolicy="NEVER" minWidth="990.0" prefHeight="73.0" prefWidth="990.0" style="-fx-background-color: transparent;" styleClass="result-display" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <VBox alignment="CENTER_LEFT">
       <children>
          <Label fx:id="resultDisplay" lineSpacing="1.0" maxHeight="-Infinity" minHeight="53.0" minWidth="-Infinity" prefWidth="950.0" styleClass="result-display-label" text="The command's response will be displayed here" wrapText="true" />

--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -4,9 +4,13 @@
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
 
-<StackPane fx:id="placeHolder" alignment="CENTER_LEFT" prefHeight="73.0" prefWidth="990.0" styleClass="result-display" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
-   <Label fx:id="resultDisplay" lineSpacing="1.0" prefHeight="53.0" prefWidth="950.0" styleClass="result-display" text="The command's response will be displayed here" wrapText="true" />
+<ScrollPane fx:id="placeHolder" hbarPolicy="NEVER" minWidth="990.0" prefHeight="73.0" prefWidth="990.0" style="-fx-background-color: transparent;" styleClass="result-display" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
+   <VBox alignment="CENTER_LEFT">
+      <children>
+         <Label fx:id="resultDisplay" lineSpacing="1.0" maxHeight="-Infinity" minHeight="53.0" minWidth="-Infinity" prefWidth="950.0" styleClass="result-display-label" text="The command's response will be displayed here" wrapText="true" />
+      </children>
+   </VBox>
    <padding>
       <Insets bottom="10.0" left="20.0" right="20.0" top="10.0" />
    </padding>
-</StackPane>
+</ScrollPane>

--- a/src/test/java/peoplesoft/logic/LogicManagerTest.java
+++ b/src/test/java/peoplesoft/logic/LogicManagerTest.java
@@ -59,13 +59,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
-<<<<<<< HEAD
         String deleteCommand = "persondelete 9";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-=======
-        String deleteCommand = "delete 9";
         assertCommandException(deleteCommand, MSG_INVALID_PERSON_DISPLAYED_IDX);
->>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands)
     }
 
     @Test

--- a/src/test/java/peoplesoft/logic/LogicManagerTest.java
+++ b/src/test/java/peoplesoft/logic/LogicManagerTest.java
@@ -1,8 +1,8 @@
 package peoplesoft.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
-import static peoplesoft.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_PERSON_DISPLAYED_IDX;
+import static peoplesoft.commons.core.Messages.MSG_UNKNOWN_CMD;
 import static peoplesoft.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static peoplesoft.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static peoplesoft.logic.commands.CommandTestUtil.NAME_DESC_AMY;
@@ -54,13 +54,18 @@ public class LogicManagerTest {
     @Test
     public void execute_invalidCommandFormat_throwsParseException() {
         String invalidCommand = "uicfhmowqewca";
-        assertParseException(invalidCommand, MESSAGE_UNKNOWN_COMMAND);
+        assertParseException(invalidCommand, MSG_UNKNOWN_CMD);
     }
 
     @Test
     public void execute_commandExecutionError_throwsCommandException() {
+<<<<<<< HEAD
         String deleteCommand = "persondelete 9";
         assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+=======
+        String deleteCommand = "delete 9";
+        assertCommandException(deleteCommand, MSG_INVALID_PERSON_DISPLAYED_IDX);
+>>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands)
     }
 
     @Test

--- a/src/test/java/peoplesoft/logic/commands/job/JobFinalizeCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobFinalizeCommandTest.java
@@ -46,7 +46,7 @@ public class JobFinalizeCommandTest {
     public void execute_incorrectArgs_throwsCommandException() {
         // No job at index 3
         JobFinalizeCommand cmd = new JobFinalizeCommand(Index.fromOneBased(3), new Employment());
-        assertCommandFailure(cmd, expectedModel, Messages.MESSAGE_INVALID_JOB_DISPLAYED_INDEX);
+        assertCommandFailure(cmd, expectedModel, Messages.MSG_INVALID_JOB_DISPLAYED_IDX);
     }
 
     @Test

--- a/src/test/java/peoplesoft/logic/commands/job/JobMarkCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobMarkCommandTest.java
@@ -48,7 +48,7 @@ public class JobMarkCommandTest {
     public void execute_incorrectArgs_throwsCommandException() {
         // No job at index 3
         JobMarkCommand cmd = new JobMarkCommand(Index.fromOneBased(3), new Employment());
-        assertCommandFailure(cmd, expectedModel, Messages.MESSAGE_INVALID_JOB_DISPLAYED_INDEX);
+        assertCommandFailure(cmd, expectedModel, Messages.MSG_INVALID_JOB_DISPLAYED_IDX);
     }
 
     @Test

--- a/src/test/java/peoplesoft/logic/commands/job/JobMarkCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobMarkCommandTest.java
@@ -65,14 +65,14 @@ public class JobMarkCommandTest {
         expectedModel.addJob(PAID);
         expectedModel.setPerson(ALICE, aliceToo);
         JobMarkCommand cmd = new JobMarkCommand(Index.fromOneBased(1), emp);
-        assertCommandSuccess(cmd, model, String.format(JobMarkCommand.MESSAGE_SUCCESS, PAID.getDesc(), "paid"),
+        assertCommandSuccess(cmd, model, String.format(JobMarkCommand.MESSAGE_SUCCESS, PAID.getDesc(), "Paid"),
                 expectedModel);
 
         // Mark as not paid
         expectedModel.setJob(PAID, UNPAID);
         expectedModel.setPerson(aliceToo, ALICE);
         cmd = new JobMarkCommand(Index.fromOneBased(1), emp);
-        assertCommandSuccess(cmd, model, String.format(JobMarkCommand.MESSAGE_SUCCESS, UNPAID.getDesc(), "not paid"),
+        assertCommandSuccess(cmd, model, String.format(JobMarkCommand.MESSAGE_SUCCESS, UNPAID.getDesc(), "Not Paid"),
                 expectedModel);
     }
 }

--- a/src/test/java/peoplesoft/logic/commands/job/JobPersonDeleteCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobPersonDeleteCommandTest.java
@@ -39,7 +39,7 @@ public class JobPersonDeleteCommandTest {
     public void execute_incorrectArgs_throwsCommandException() {
         // No job at index 3
         JobDeleteCommand cmd = new JobDeleteCommand(Index.fromOneBased(3));
-        assertCommandFailure(cmd, expectedModel, Messages.MESSAGE_INVALID_JOB_DISPLAYED_INDEX);
+        assertCommandFailure(cmd, expectedModel, Messages.MSG_INVALID_JOB_DISPLAYED_IDX);
     }
 
     @Test

--- a/src/test/java/peoplesoft/logic/commands/job/JobPersonFindCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/job/JobPersonFindCommandTest.java
@@ -29,7 +29,7 @@ public class JobPersonFindCommandTest {
     public void execute_zeroKeywords_noPersonFound() {
         model.addJob(JOB);
         expectedModel.addJob(JOB);
-        String expectedMessage = String.format(Messages.MESSAGE_JOBS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(Messages.MSG_JOBS_LISTED_OVERVIEW, 0);
         JobContainsKeywordsPredicate predicate = preparePredicate(" ");
         JobFindCommand command = new JobFindCommand(predicate);
         expectedModel.updateFilteredJobList(predicate);
@@ -41,7 +41,7 @@ public class JobPersonFindCommandTest {
     public void execute_multipleKeywords_multiplePersonsFound() {
         model.addJob(JOB);
         expectedModel.addJob(JOB);
-        String expectedMessage = String.format(Messages.MESSAGE_JOBS_LISTED_OVERVIEW, 1);
+        String expectedMessage = String.format(Messages.MSG_JOBS_LISTED_OVERVIEW, 1);
         JobContainsKeywordsPredicate predicate = preparePredicate("right");
         JobFindCommand command = new JobFindCommand(predicate);
         expectedModel.updateFilteredJobList(predicate);

--- a/src/test/java/peoplesoft/logic/commands/person/PersonAddCommandIntegrationTest.java
+++ b/src/test/java/peoplesoft/logic/commands/person/PersonAddCommandIntegrationTest.java
@@ -34,7 +34,7 @@ public class PersonAddCommandIntegrationTest {
         expectedModel.addPerson(validPerson);
 
         assertCommandSuccess(new PersonAddCommand(validPerson), model,
-                String.format(PersonAddCommand.MESSAGE_SUCCESS, validPerson), expectedModel);
+                String.format(PersonAddCommand.MESSAGE_SUCCESS, validPerson.getName()), expectedModel);
     }
 
     @Test

--- a/src/test/java/peoplesoft/logic/commands/person/PersonAddCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/person/PersonAddCommandTest.java
@@ -33,7 +33,8 @@ public class PersonAddCommandTest {
 
         CommandResult commandResult = new PersonAddCommand(validPerson).execute(modelStub);
 
-        assertEquals(String.format(PersonAddCommand.MESSAGE_SUCCESS, validPerson.getName()), commandResult.getFeedbackToUser());
+        assertEquals(String.format(PersonAddCommand.MESSAGE_SUCCESS, validPerson.getName()),
+                commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
     }
 

--- a/src/test/java/peoplesoft/logic/commands/person/PersonAddCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/person/PersonAddCommandTest.java
@@ -33,7 +33,7 @@ public class PersonAddCommandTest {
 
         CommandResult commandResult = new PersonAddCommand(validPerson).execute(modelStub);
 
-        assertEquals(String.format(PersonAddCommand.MESSAGE_SUCCESS, validPerson), commandResult.getFeedbackToUser());
+        assertEquals(String.format(PersonAddCommand.MESSAGE_SUCCESS, validPerson.getName()), commandResult.getFeedbackToUser());
         assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
     }
 

--- a/src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
@@ -31,7 +31,8 @@ public class PersonDeleteCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         PersonDeleteCommand personDeleteCommand = new PersonDeleteCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(PersonDeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete.getName());
+        String expectedMessage = String.format(PersonDeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                personToDelete.getName());
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -54,7 +55,8 @@ public class PersonDeleteCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         PersonDeleteCommand personDeleteCommand = new PersonDeleteCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(PersonDeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete.getName());
+        String expectedMessage = String.format(PersonDeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS,
+                personToDelete.getName());
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);

--- a/src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
@@ -44,7 +44,11 @@ public class PersonDeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         PersonDeleteCommand personDeleteCommand = new PersonDeleteCommand(outOfBoundIndex);
 
+<<<<<<< HEAD:src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
         assertCommandFailure(personDeleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+=======
+        assertCommandFailure(deleteCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
+>>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/commands/DeleteCommandTest.java
     }
 
     @Test
@@ -73,7 +77,11 @@ public class PersonDeleteCommandTest {
 
         PersonDeleteCommand personDeleteCommand = new PersonDeleteCommand(outOfBoundIndex);
 
+<<<<<<< HEAD:src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
         assertCommandFailure(personDeleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+=======
+        assertCommandFailure(deleteCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
+>>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/commands/DeleteCommandTest.java
     }
 
     @Test

--- a/src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
@@ -31,7 +31,7 @@ public class PersonDeleteCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         PersonDeleteCommand personDeleteCommand = new PersonDeleteCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(PersonDeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        String expectedMessage = String.format(PersonDeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete.getName());
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);
@@ -54,7 +54,7 @@ public class PersonDeleteCommandTest {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         PersonDeleteCommand personDeleteCommand = new PersonDeleteCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(PersonDeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+        String expectedMessage = String.format(PersonDeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete.getName());
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(personToDelete);

--- a/src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
@@ -44,11 +44,7 @@ public class PersonDeleteCommandTest {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         PersonDeleteCommand personDeleteCommand = new PersonDeleteCommand(outOfBoundIndex);
 
-<<<<<<< HEAD:src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
-        assertCommandFailure(personDeleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-=======
-        assertCommandFailure(deleteCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
->>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/commands/DeleteCommandTest.java
+        assertCommandFailure(personDeleteCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
     }
 
     @Test
@@ -77,11 +73,7 @@ public class PersonDeleteCommandTest {
 
         PersonDeleteCommand personDeleteCommand = new PersonDeleteCommand(outOfBoundIndex);
 
-<<<<<<< HEAD:src/test/java/peoplesoft/logic/commands/person/PersonDeleteCommandTest.java
-        assertCommandFailure(personDeleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-=======
-        assertCommandFailure(deleteCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
->>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/commands/DeleteCommandTest.java
+        assertCommandFailure(personDeleteCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
     }
 
     @Test

--- a/src/test/java/peoplesoft/logic/commands/person/PersonEditCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/person/PersonEditCommandTest.java
@@ -107,11 +107,7 @@ public class PersonEditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
         PersonEditCommand personEditCommand = new PersonEditCommand(outOfBoundIndex, descriptor);
 
-<<<<<<< HEAD:src/test/java/peoplesoft/logic/commands/person/PersonEditCommandTest.java
-        assertCommandFailure(personEditCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-=======
-        assertCommandFailure(editCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
->>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/commands/EditCommandTest.java
+        assertCommandFailure(personEditCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
     }
 
     /**
@@ -128,11 +124,7 @@ public class PersonEditCommandTest {
         PersonEditCommand personEditCommand = new PersonEditCommand(outOfBoundIndex,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-<<<<<<< HEAD:src/test/java/peoplesoft/logic/commands/person/PersonEditCommandTest.java
-        assertCommandFailure(personEditCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
-=======
-        assertCommandFailure(editCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
->>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/commands/EditCommandTest.java
+        assertCommandFailure(personEditCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
     }
 
     @Test

--- a/src/test/java/peoplesoft/logic/commands/person/PersonEditCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/person/PersonEditCommandTest.java
@@ -43,7 +43,7 @@ public class PersonEditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(editedPerson).build();
         PersonEditCommand personEditCommand = new PersonEditCommand(INDEX_FIRST_PERSON, descriptor);
 
-        String expectedMessage = String.format(PersonEditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+        String expectedMessage = String.format(PersonEditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson.getName());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);
@@ -64,7 +64,7 @@ public class PersonEditCommandTest {
                 .withPhone(VALID_PHONE_BOB).withTags(VALID_TAG_HUSBAND).build();
         PersonEditCommand personEditCommand = new PersonEditCommand(indexLastPerson, descriptor);
 
-        String expectedMessage = String.format(PersonEditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+        String expectedMessage = String.format(PersonEditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson.getName());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(lastPerson, editedPerson);
@@ -77,7 +77,7 @@ public class PersonEditCommandTest {
         PersonEditCommand personEditCommand = new PersonEditCommand(INDEX_FIRST_PERSON, new EditPersonDescriptor());
         Person editedPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
 
-        String expectedMessage = String.format(PersonEditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+        String expectedMessage = String.format(PersonEditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson.getName());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
@@ -93,7 +93,7 @@ public class PersonEditCommandTest {
         PersonEditCommand personEditCommand = new PersonEditCommand(INDEX_FIRST_PERSON,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
-        String expectedMessage = String.format(PersonEditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson);
+        String expectedMessage = String.format(PersonEditCommand.MESSAGE_EDIT_PERSON_SUCCESS, editedPerson.getName());
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
         expectedModel.setPerson(model.getFilteredPersonList().get(0), editedPerson);

--- a/src/test/java/peoplesoft/logic/commands/person/PersonEditCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/person/PersonEditCommandTest.java
@@ -107,7 +107,11 @@ public class PersonEditCommandTest {
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build();
         PersonEditCommand personEditCommand = new PersonEditCommand(outOfBoundIndex, descriptor);
 
+<<<<<<< HEAD:src/test/java/peoplesoft/logic/commands/person/PersonEditCommandTest.java
         assertCommandFailure(personEditCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+=======
+        assertCommandFailure(editCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
+>>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/commands/EditCommandTest.java
     }
 
     /**
@@ -124,7 +128,11 @@ public class PersonEditCommandTest {
         PersonEditCommand personEditCommand = new PersonEditCommand(outOfBoundIndex,
                 new EditPersonDescriptorBuilder().withName(VALID_NAME_BOB).build());
 
+<<<<<<< HEAD:src/test/java/peoplesoft/logic/commands/person/PersonEditCommandTest.java
         assertCommandFailure(personEditCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+=======
+        assertCommandFailure(editCommand, model, Messages.MSG_INVALID_PERSON_DISPLAYED_IDX);
+>>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/commands/EditCommandTest.java
     }
 
     @Test

--- a/src/test/java/peoplesoft/logic/commands/person/PersonFindCommandTest.java
+++ b/src/test/java/peoplesoft/logic/commands/person/PersonFindCommandTest.java
@@ -3,7 +3,7 @@ package peoplesoft.logic.commands.person;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static peoplesoft.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
+import static peoplesoft.commons.core.Messages.MSG_PERSONS_LISTED_OVERVIEW;
 import static peoplesoft.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static peoplesoft.testutil.TypicalPersons.BENSON;
 import static peoplesoft.testutil.TypicalPersons.DANIEL;
@@ -56,7 +56,7 @@ public class PersonFindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        String expectedMessage = String.format(MSG_PERSONS_LISTED_OVERVIEW, 0);
         PersonContainsKeywordsPredicate predicate = preparePredicate(" ");
         PersonFindCommand command = new PersonFindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -66,7 +66,7 @@ public class PersonFindCommandTest {
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
-        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        String expectedMessage = String.format(MSG_PERSONS_LISTED_OVERVIEW, 2);
         PersonContainsKeywordsPredicate predicate = preparePredicate("Meier friends");
         PersonFindCommand command = new PersonFindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);

--- a/src/test/java/peoplesoft/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/AddressBookParserTest.java
@@ -2,8 +2,8 @@ package peoplesoft.logic.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static peoplesoft.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_UNKNOWN_CMD;
 import static peoplesoft.testutil.Assert.assertThrows;
 import static peoplesoft.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -90,12 +90,12 @@ public class AddressBookParserTest {
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
+        assertThrows(ParseException.class, String.format(MSG_INVALID_CMD_FORMAT, HelpCommand.MESSAGE_USAGE), ()
                 -> parser.parseCommand(""));
     }
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+        assertThrows(ParseException.class, MSG_UNKNOWN_CMD, () -> parser.parseCommand("unknownCommand"));
     }
 }

--- a/src/test/java/peoplesoft/logic/parser/job/JobAddCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobAddCommandParserTest.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_DURATION;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -13,7 +13,7 @@ import peoplesoft.logic.parser.ParserUtil;
 public class JobAddCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, JobAddCommand.MESSAGE_USAGE);
+            String.format(MSG_INVALID_CMD_FORMAT, JobAddCommand.MESSAGE_USAGE);
 
     private static final String VALID_NAME = " " + PREFIX_NAME + "name";
     private static final String VALID_DURATION = " " + PREFIX_DURATION + "3";

--- a/src/test/java/peoplesoft/logic/parser/job/JobAddCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobAddCommandParserTest.java
@@ -1,5 +1,7 @@
 package peoplesoft.logic.parser.job;
 
+import static peoplesoft.commons.core.Messages.MSG_DURATION_CONSTRAINTS;
+import static peoplesoft.commons.core.Messages.MSG_EMPTY_STRING;
 import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_DURATION;
 import static peoplesoft.logic.parser.CliSyntax.PREFIX_NAME;
@@ -8,7 +10,6 @@ import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseFailure;
 import org.junit.jupiter.api.Test;
 
 import peoplesoft.logic.commands.job.JobAddCommand;
-import peoplesoft.logic.parser.ParserUtil;
 
 public class JobAddCommandParserTest {
 
@@ -38,13 +39,13 @@ public class JobAddCommandParserTest {
     }
 
     @Test
-    public void parse_wrongFormatArgs_throwsParseException() {
+    public void parse_emptyNameArgs_throwsParseException() {
         // Empty name
         assertParseFailure(parser, INVALID_NAME + VALID_DURATION,
-                ParserUtil.STRING_MESSAGE_CONSTRAINTS);
+                MSG_EMPTY_STRING);
 
         // Incorrect duration parse
         assertParseFailure(parser, VALID_NAME + INVALID_DURATION,
-                ParserUtil.DURATION_MESSAGE_CONSTRAINTS);
+                MSG_DURATION_CONSTRAINTS);
     }
 }

--- a/src/test/java/peoplesoft/logic/parser/job/JobAssignCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobAssignCommandParserTest.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -16,7 +16,7 @@ import peoplesoft.model.employment.Employment;
 public class JobAssignCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, JobAssignCommand.MESSAGE_USAGE);
+            String.format(MSG_INVALID_CMD_FORMAT, JobAssignCommand.MESSAGE_USAGE);
 
     private JobAssignCommandParser parser = new JobAssignCommandParser();
 

--- a/src/test/java/peoplesoft/logic/parser/job/JobDeleteCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobDeleteCommandParserTest.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -12,7 +12,7 @@ import peoplesoft.logic.commands.job.JobDeleteCommand;
 public class JobDeleteCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, JobDeleteCommand.MESSAGE_USAGE);
+            String.format(MSG_INVALID_CMD_FORMAT, JobDeleteCommand.MESSAGE_USAGE);
 
     private static final String WHITESPACE = " \t\r\n";
 

--- a/src/test/java/peoplesoft/logic/parser/job/JobFinalizeCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobFinalizeCommandParserTest.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -13,7 +13,7 @@ import peoplesoft.model.employment.Employment;
 public class JobFinalizeCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, JobFinalizeCommand.MESSAGE_USAGE);
+            String.format(MSG_INVALID_CMD_FORMAT, JobFinalizeCommand.MESSAGE_USAGE);
 
     private JobFinalizeCommandParser parser = new JobFinalizeCommandParser();
 

--- a/src/test/java/peoplesoft/logic/parser/job/JobFindCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobFindCommandParserTest.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -17,7 +17,7 @@ public class JobFindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, " \r\t\n", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+        assertParseFailure(parser, " \r\t\n", String.format(MSG_INVALID_CMD_FORMAT,
                 JobFindCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/peoplesoft/logic/parser/job/JobMarkCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/job/JobMarkCommandParserTest.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.job;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -13,7 +13,7 @@ import peoplesoft.model.employment.Employment;
 public class JobMarkCommandParserTest {
 
     private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, JobMarkCommand.MESSAGE_USAGE);
+            String.format(MSG_INVALID_CMD_FORMAT, JobMarkCommand.MESSAGE_USAGE);
 
     private static final String WHITESPACE = " \t\r\n";
 

--- a/src/test/java/peoplesoft/logic/parser/person/PersonAddCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/person/PersonAddCommandParserTest.java
@@ -99,11 +99,7 @@ public class PersonAddCommandParserTest {
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
-<<<<<<< HEAD:src/test/java/peoplesoft/logic/parser/person/PersonAddCommandParserTest.java
-        String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonAddCommand.MESSAGE_USAGE);
-=======
-        String expectedMessage = String.format(MSG_INVALID_CMD_FORMAT, AddCommand.MESSAGE_USAGE);
->>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/parser/AddCommandParserTest.java
+        String expectedMessage = String.format(MSG_INVALID_CMD_FORMAT, PersonAddCommand.MESSAGE_USAGE);
 
         // missing name prefix
         assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
@@ -164,10 +160,6 @@ public class PersonAddCommandParserTest {
         assertParseFailure(parser,
                 PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                         + ADDRESS_DESC_BOB + RATE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-<<<<<<< HEAD:src/test/java/peoplesoft/logic/parser/person/PersonAddCommandParserTest.java
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonAddCommand.MESSAGE_USAGE));
-=======
-                String.format(MSG_INVALID_CMD_FORMAT, AddCommand.MESSAGE_USAGE));
->>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/parser/AddCommandParserTest.java
+                String.format(MSG_INVALID_CMD_FORMAT, PersonAddCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/peoplesoft/logic/parser/person/PersonAddCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/person/PersonAddCommandParserTest.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.person;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static peoplesoft.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -99,7 +99,11 @@ public class PersonAddCommandParserTest {
 
     @Test
     public void parse_compulsoryFieldMissing_failure() {
+<<<<<<< HEAD:src/test/java/peoplesoft/logic/parser/person/PersonAddCommandParserTest.java
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonAddCommand.MESSAGE_USAGE);
+=======
+        String expectedMessage = String.format(MSG_INVALID_CMD_FORMAT, AddCommand.MESSAGE_USAGE);
+>>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/parser/AddCommandParserTest.java
 
         // missing name prefix
         assertParseFailure(parser, VALID_NAME_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
@@ -160,6 +164,10 @@ public class PersonAddCommandParserTest {
         assertParseFailure(parser,
                 PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                         + ADDRESS_DESC_BOB + RATE_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+<<<<<<< HEAD:src/test/java/peoplesoft/logic/parser/person/PersonAddCommandParserTest.java
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonAddCommand.MESSAGE_USAGE));
+=======
+                String.format(MSG_INVALID_CMD_FORMAT, AddCommand.MESSAGE_USAGE));
+>>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/parser/AddCommandParserTest.java
     }
 }

--- a/src/test/java/peoplesoft/logic/parser/person/PersonDeleteCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/person/PersonDeleteCommandParserTest.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.person;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static peoplesoft.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
@@ -27,7 +27,11 @@ public class PersonDeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
+<<<<<<< HEAD:src/test/java/peoplesoft/logic/parser/person/PersonDeleteCommandParserTest.java
         assertParseFailure(parser, "a",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonDeleteCommand.MESSAGE_USAGE));
+=======
+        assertParseFailure(parser, "a", String.format(MSG_INVALID_CMD_FORMAT, DeleteCommand.MESSAGE_USAGE));
+>>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/parser/DeleteCommandParserTest.java
     }
 }

--- a/src/test/java/peoplesoft/logic/parser/person/PersonDeleteCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/person/PersonDeleteCommandParserTest.java
@@ -27,11 +27,7 @@ public class PersonDeleteCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
-<<<<<<< HEAD:src/test/java/peoplesoft/logic/parser/person/PersonDeleteCommandParserTest.java
         assertParseFailure(parser, "a",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonDeleteCommand.MESSAGE_USAGE));
-=======
-        assertParseFailure(parser, "a", String.format(MSG_INVALID_CMD_FORMAT, DeleteCommand.MESSAGE_USAGE));
->>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/parser/DeleteCommandParserTest.java
+                String.format(MSG_INVALID_CMD_FORMAT, PersonDeleteCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/peoplesoft/logic/parser/person/PersonEditCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/person/PersonEditCommandParserTest.java
@@ -48,11 +48,7 @@ public class PersonEditCommandParserTest {
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
     private static final String MESSAGE_INVALID_FORMAT =
-<<<<<<< HEAD:src/test/java/peoplesoft/logic/parser/person/PersonEditCommandParserTest.java
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonEditCommand.MESSAGE_USAGE);
-=======
-            String.format(MSG_INVALID_CMD_FORMAT, EditCommand.MESSAGE_USAGE);
->>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/parser/EditCommandParserTest.java
+            String.format(MSG_INVALID_CMD_FORMAT, PersonEditCommand.MESSAGE_USAGE);
 
     private PersonEditCommandParser parser = new PersonEditCommandParser();
 

--- a/src/test/java/peoplesoft/logic/parser/person/PersonEditCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/person/PersonEditCommandParserTest.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.person;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static peoplesoft.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static peoplesoft.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
@@ -48,7 +48,11 @@ public class PersonEditCommandParserTest {
     private static final String TAG_EMPTY = " " + PREFIX_TAG;
 
     private static final String MESSAGE_INVALID_FORMAT =
+<<<<<<< HEAD:src/test/java/peoplesoft/logic/parser/person/PersonEditCommandParserTest.java
             String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonEditCommand.MESSAGE_USAGE);
+=======
+            String.format(MSG_INVALID_CMD_FORMAT, EditCommand.MESSAGE_USAGE);
+>>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/parser/EditCommandParserTest.java
 
     private PersonEditCommandParser parser = new PersonEditCommandParser();
 

--- a/src/test/java/peoplesoft/logic/parser/person/PersonFindCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/person/PersonFindCommandParserTest.java
@@ -1,6 +1,6 @@
 package peoplesoft.logic.parser.person;
 
-import static peoplesoft.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static peoplesoft.commons.core.Messages.MSG_INVALID_CMD_FORMAT;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static peoplesoft.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -17,8 +17,12 @@ public class PersonFindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
+<<<<<<< HEAD:src/test/java/peoplesoft/logic/parser/person/PersonFindCommandParserTest.java
         assertParseFailure(parser, "     ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonFindCommand.MESSAGE_USAGE));
+=======
+        assertParseFailure(parser, "     ", String.format(MSG_INVALID_CMD_FORMAT, FindCommand.MESSAGE_USAGE));
+>>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/parser/FindCommandParserTest.java
     }
 
     @Test

--- a/src/test/java/peoplesoft/logic/parser/person/PersonFindCommandParserTest.java
+++ b/src/test/java/peoplesoft/logic/parser/person/PersonFindCommandParserTest.java
@@ -17,12 +17,8 @@ public class PersonFindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-<<<<<<< HEAD:src/test/java/peoplesoft/logic/parser/person/PersonFindCommandParserTest.java
         assertParseFailure(parser, "     ",
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PersonFindCommand.MESSAGE_USAGE));
-=======
-        assertParseFailure(parser, "     ", String.format(MSG_INVALID_CMD_FORMAT, FindCommand.MESSAGE_USAGE));
->>>>>>> a2a3ef33 (Debug and fix ResultDisplay messages for all job commands):src/test/java/peoplesoft/logic/parser/FindCommandParserTest.java
+                String.format(MSG_INVALID_CMD_FORMAT, PersonFindCommand.MESSAGE_USAGE));
     }
 
     @Test


### PR DESCRIPTION
- [x] Edit all messages to fit within 3 lines 
    - [x] job commands
    - [x] person commands
    - [x] general commands
- [x] For messages that cannot fit (like the email one), enable scrolling
- [x] Edit the language of the messages. Some were clearly not designed to be read by the user like "Expected ... string"
- [x] Edit tests to pass with the new messages
- [ ] `Job list`: shrink the Duration column slightly, give more space to the Done column