### PR TITLE
Fix GUI size issues

### DIFF
--- a/src/main/java/peoplesoft/commons/core/GuiSettings.java
+++ b/src/main/java/peoplesoft/commons/core/GuiSettings.java
@@ -1,17 +1,21 @@
 package peoplesoft.commons.core;
 
 import java.awt.Point;
-import java.io.Serializable;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * A Serializable class that contains the GUI settings.
  * Guarantees: immutable.
  */
-public class GuiSettings implements Serializable {
+public class GuiSettings {
+    public static final double MIN_WIDTH = 1250;
+    public static final double MIN_HEIGHT = 500;
 
-    private static final double DEFAULT_HEIGHT = 720;
     private static final double DEFAULT_WIDTH = 1280;
+    private static final double DEFAULT_HEIGHT = 720;
 
     private final double windowWidth;
     private final double windowHeight;
@@ -29,9 +33,15 @@ public class GuiSettings implements Serializable {
     /**
      * Constructs a {@code GuiSettings} with the specified height, width and position.
      */
-    public GuiSettings(double windowWidth, double windowHeight, int xPosition, int yPosition) {
-        this.windowWidth = windowWidth;
-        this.windowHeight = windowHeight;
+    @JsonCreator
+    public GuiSettings(
+            @JsonProperty("windowWidth") double windowWidth,
+            @JsonProperty("windowHeight") double windowHeight,
+            @JsonProperty("xPosition") int xPosition,
+            @JsonProperty("yPosition") int yPosition) {
+        // silently coerce loaded widths/heights to the minimum
+        this.windowWidth = Math.max(windowWidth, MIN_WIDTH);
+        this.windowHeight = Math.max(windowHeight, MIN_HEIGHT);
         windowCoordinates = new Point(xPosition, yPosition);
     }
 

--- a/src/main/java/peoplesoft/ui/regions/JobCard.java
+++ b/src/main/java/peoplesoft/ui/regions/JobCard.java
@@ -1,16 +1,17 @@
 package peoplesoft.ui.regions;
 
-// import java.util.Comparator;
-
+import java.util.List;
 import java.util.Objects;
 
+import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-// import javafx.scene.layout.FlowPane;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
+import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+import javafx.scene.layout.StackPane;
 import peoplesoft.model.job.Job;
 import peoplesoft.ui.UiPart;
 
@@ -38,19 +39,32 @@ public class JobCard extends UiPart<Region> {
     @FXML
     private Label duration; // 1H0M
     @FXML
+    private StackPane doneIconCol;
+    @FXML
     private ImageView doneIcon; // false
     @FXML
+    private StackPane paidForIconCol;
+    @FXML
     private ImageView paidForIcon; // false
-    // @FXML
-    // private FlowPane involved; // Todo: get the associated people from employment to display in here
+    @FXML
+    private FlowPane involved; // Todo: get the associated people from employment to display in here
     // @FXML
     // private FlowPane tags; // Todo: implement tags when oviya merges her part
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
-    public JobCard(Job job, int displayedIndex) {
+    public JobCard(Job job, int displayedIndex, List<ReadOnlyDoubleProperty> colWidths) {
         super(FXML);
+
+        List<? extends Region> cols = List.of(idx, desc, duration, doneIconCol, paidForIconCol, involved);
+        if (cols.size() != colWidths.size()) {
+            throw new RuntimeException("JobCard colWidths count != cols count");
+        }
+        for (int i = 0; i < cols.size(); i++) {
+            cols.get(i).minWidthProperty().bind(colWidths.get(i));
+            cols.get(i).maxWidthProperty().bind(colWidths.get(i));
+        }
 
         // calculate time
         int hH = job.getDuration().toHoursPart();

--- a/src/main/java/peoplesoft/ui/regions/JobListPanel.java
+++ b/src/main/java/peoplesoft/ui/regions/JobListPanel.java
@@ -1,7 +1,9 @@
 package peoplesoft.ui.regions;
 
+import java.util.List;
 import java.util.logging.Logger;
 
+import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
@@ -18,14 +20,17 @@ public class JobListPanel extends UiPart<Region> {
     private static final String FXML = "JobListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(JobListPanel.class);
 
+    private List<ReadOnlyDoubleProperty> colWidths;
+
     @FXML
     private ListView<Job> jobListView;
 
     /**
      * Creates a {@code JobListPanel} with the given {@code ObservableList}.
      */
-    public JobListPanel(ObservableList<Job> jobList) {
+    public JobListPanel(ObservableList<Job> jobList, List<ReadOnlyDoubleProperty> colWidths) {
         super(FXML);
+        this.colWidths = colWidths;
         jobListView.setItems(jobList);
         jobListView.setCellFactory(listView -> new JobListViewCell());
     }
@@ -45,7 +50,7 @@ public class JobListPanel extends UiPart<Region> {
                 // add a new divider before also!
                 // <StackPane fx:id="divider" layoutX="10.0" layoutY="21.0"
                 // prefHeight="2.0" style="-fx-background-color: #33344B;" />
-                setGraphic(new JobCard(job, getIndex() + 1).getRoot());
+                setGraphic(new JobCard(job, getIndex() + 1, colWidths).getRoot());
             }
         }
     }

--- a/src/main/java/peoplesoft/ui/regions/PersonCard.java
+++ b/src/main/java/peoplesoft/ui/regions/PersonCard.java
@@ -1,6 +1,7 @@
 package peoplesoft.ui.regions;
 
 import java.util.Comparator;
+import java.util.List;
 
 import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.collections.ObservableList;
@@ -45,8 +46,18 @@ public class PersonCard extends UiPart<Region> {
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
-    public PersonCard(Person person, int displayedIndex) {
+    public PersonCard(Person person, int displayedIndex, List<ReadOnlyDoubleProperty> colWidths) {
         super(FXML);
+
+        List<? extends Region> cols = List.of(idx, name, amtDue, tags, phone, basePay, email, address);
+        if (cols.size() != colWidths.size()) {
+            throw new RuntimeException("JobCard colWidths count != cols count");
+        }
+        for (int i = 0; i < cols.size(); i++) {
+            cols.get(i).minWidthProperty().bind(colWidths.get(i));
+            cols.get(i).maxWidthProperty().bind(colWidths.get(i));
+        }
+
         this.person = person;
         idx.setText(displayedIndex + "");
         name.setText(person.getName().fullName);

--- a/src/main/java/peoplesoft/ui/regions/PersonListPanel.java
+++ b/src/main/java/peoplesoft/ui/regions/PersonListPanel.java
@@ -1,7 +1,9 @@
 package peoplesoft.ui.regions;
 
+import java.util.List;
 import java.util.logging.Logger;
 
+import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
@@ -18,14 +20,17 @@ public class PersonListPanel extends UiPart<Region> {
     private static final String FXML = "PersonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
 
+    private List<ReadOnlyDoubleProperty> colWidths;
+
     @FXML
     private ListView<Person> personListView;
 
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList) {
+    public PersonListPanel(ObservableList<Person> personList, List<ReadOnlyDoubleProperty> colWidths) {
         super(FXML);
+        this.colWidths = colWidths;
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
     }
@@ -45,7 +50,7 @@ public class PersonListPanel extends UiPart<Region> {
                 // add a new divider before also!
                 // <StackPane fx:id="divider" layoutX="10.0" layoutY="21.0"
                 // prefHeight="2.0" style="-fx-background-color: #33344B;" />
-                setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
+                setGraphic(new PersonCard(person, getIndex() + 1, colWidths).getRoot());
             }
         }
     }

--- a/src/main/java/peoplesoft/ui/scenes/OverviewPage.java
+++ b/src/main/java/peoplesoft/ui/scenes/OverviewPage.java
@@ -1,9 +1,15 @@
 package peoplesoft.ui.scenes;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
+import javafx.beans.property.ReadOnlyDoubleProperty;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 import peoplesoft.commons.core.LogsCenter;
 import peoplesoft.model.job.Job;
@@ -19,10 +25,14 @@ public class OverviewPage extends Page {
     private JobListPanel jobListPanel;
 
     @FXML
+    private HBox personListHeader;
+    @FXML
+    private HBox jobListHeader;
+
+    @FXML
     private StackPane personListPanelPlaceholder;
     @FXML
     private StackPane jobListPanelPlaceholder;
-
 
     /**
      * Creates a {@code OverPage} with the given {@code ObservableList<Person>}
@@ -30,10 +40,18 @@ public class OverviewPage extends Page {
     public OverviewPage(ObservableList<Person> filteredPersonList, ObservableList<Job> filteredJobList) {
         super(FXML);
         logger.fine("Opening PeopleSoft's Overview page.");
-        personListPanel = new PersonListPanel(filteredPersonList);
-        jobListPanel = new JobListPanel(filteredJobList);
+        List<ReadOnlyDoubleProperty> personColWidths = personListHeader.getChildren().stream()
+                .map(node -> ((Region) node).widthProperty())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toUnmodifiableList());
+        personListPanel = new PersonListPanel(filteredPersonList, personColWidths);
+
+        List<ReadOnlyDoubleProperty> jobColWidths = jobListHeader.getChildren().stream()
+                .map(node -> ((Region) node).widthProperty())
+                .collect(Collectors.toList());
+        jobListPanel = new JobListPanel(filteredJobList, jobColWidths);
+
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
         jobListPanelPlaceholder.getChildren().add(jobListPanel.getRoot());
     }
-
 }

--- a/src/main/resources/view/JobListCard.fxml
+++ b/src/main/resources/view/JobListCard.fxml
@@ -9,10 +9,10 @@
 
 <HBox alignment="CENTER_LEFT" prefWidth="475.0" spacing="10.0" styleClass="person-card" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <Label fx:id="idx" minWidth="17.0" prefHeight="17.0" prefWidth="17.0" text="1" />
-      <Label fx:id="desc" layoutX="35.0" layoutY="27.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="Fix washing machine" wrapText="true" />
-      <Label fx:id="duration" layoutX="265.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="14h 30m" wrapText="true" />
-      <StackPane fx:id="doneIconCol" alignment="CENTER_LEFT" maxWidth="30.0" minWidth="30.0" prefWidth="30.0">
+      <Label fx:id="idx" minHeight="17.0" prefHeight="17.0" prefWidth="17.0" text="1" />
+      <Label fx:id="desc" layoutX="35.0" layoutY="27.0" prefWidth="100.0" text="Fix washing machine" wrapText="true" />
+      <Label fx:id="duration" layoutX="265.0" layoutY="27.0" prefWidth="60.0" text="14h 30m" wrapText="true" />
+      <StackPane fx:id="doneIconCol" alignment="CENTER_LEFT" prefWidth="30.0">
          <children>
             <ImageView fx:id="doneIcon" fitHeight="16.0" fitWidth="16.0" pickOnBounds="true" preserveRatio="true">
                <image>
@@ -21,7 +21,7 @@
             </ImageView>
          </children>
       </StackPane>
-      <StackPane fx:id="paidForIconCol" alignment="CENTER_LEFT" maxWidth="30.0" minWidth="30.0" prefWidth="30.0">
+      <StackPane fx:id="paidForIconCol" alignment="CENTER_LEFT" prefWidth="30.0">
          <children>
             <ImageView fx:id="paidForIcon" fitHeight="16.0" fitWidth="16.0" pickOnBounds="true" preserveRatio="true">
                <image>

--- a/src/main/resources/view/JobListCard.fxml
+++ b/src/main/resources/view/JobListCard.fxml
@@ -12,7 +12,7 @@
       <Label fx:id="idx" minWidth="17.0" prefHeight="17.0" prefWidth="17.0" text="1" />
       <Label fx:id="desc" layoutX="35.0" layoutY="27.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="Fix washing machine" wrapText="true" />
       <Label fx:id="duration" layoutX="265.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="14h 30m" wrapText="true" />
-      <StackPane alignment="CENTER_LEFT" maxWidth="30.0" minWidth="30.0" prefWidth="30.0">
+      <StackPane fx:id="doneIconCol" alignment="CENTER_LEFT" maxWidth="30.0" minWidth="30.0" prefWidth="30.0">
          <children>
             <ImageView fx:id="doneIcon" fitHeight="16.0" fitWidth="16.0" pickOnBounds="true" preserveRatio="true">
                <image>
@@ -21,7 +21,7 @@
             </ImageView>
          </children>
       </StackPane>
-      <StackPane alignment="CENTER_LEFT" maxWidth="30.0" minWidth="30.0" prefWidth="30.0">
+      <StackPane fx:id="paidForIconCol" alignment="CENTER_LEFT" maxWidth="30.0" minWidth="30.0" prefWidth="30.0">
          <children>
             <ImageView fx:id="paidForIcon" fitHeight="16.0" fitWidth="16.0" pickOnBounds="true" preserveRatio="true">
                <image>
@@ -30,6 +30,7 @@
             </ImageView>
          </children>
       </StackPane>
+      <FlowPane fx:id="involved"></FlowPane>
    </children>
    <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import java.lang.Double?>
 <?import java.net.*?>
 <?import javafx.geometry.*?>
 <?import javafx.scene.*?>
@@ -8,7 +9,13 @@
 <?import javafx.stage.*?>
 <?import peoplesoft.commons.core.GuiSettings?>
 
-<fx:root height="720.0" minHeight="${GuiSettings.MIN_HEIGHT}" minWidth="${GuiSettings.MIN_WIDTH}" onCloseRequest="#handleExit" title="PeopleSoft" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root height="720.0" onCloseRequest="#handleExit" title="PeopleSoft" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+    <minHeight>
+        <GuiSettings fx:constant="MIN_HEIGHT"/>
+    </minHeight>
+    <minWidth>
+        <GuiSettings fx:constant="MIN_WIDTH"/>
+    </minWidth>
     <icons>
         <Image url="@/images/logo/Logo32.png" />
     </icons>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -6,8 +6,9 @@
 <?import javafx.scene.image.*?>
 <?import javafx.scene.layout.*?>
 <?import javafx.stage.*?>
+<?import peoplesoft.commons.core.GuiSettings?>
 
-<fx:root height="720.0" minHeight="500.0" minWidth="1250" onCloseRequest="#handleExit" title="PeopleSoft" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root height="720.0" minHeight="${GuiSettings.MIN_HEIGHT}" minWidth="${GuiSettings.MIN_WIDTH}" onCloseRequest="#handleExit" title="PeopleSoft" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/logo/Logo32.png" />
     </icons>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -7,7 +7,7 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.stage.*?>
 
-<fx:root height="720.0" maxWidth="1280.0" minHeight="600.0" minWidth="860.0" onCloseRequest="#handleExit" title="PeopleSoft" type="javafx.stage.Stage" width="1280.0" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root height="720.0" minHeight="500.0" minWidth="1250" onCloseRequest="#handleExit" title="PeopleSoft" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
     <icons>
         <Image url="@/images/logo/Logo32.png" />
     </icons>
@@ -18,28 +18,24 @@
                 <URL value="@../styles/Extensions.css" />
             </stylesheets>
 
-            <HBox prefHeight="720.0" prefWidth="1280.0">
+            <HBox prefHeight="720.0">
                 <children>
-                    <StackPane fx:id="sideBarPlaceholder" prefHeight="720.0" prefWidth="230.0" />
-                    <BorderPane fx:id="bp" prefHeight="720.0" prefWidth="1050.0" styleClass="border-pane">
+                    <StackPane fx:id="sideBarPlaceholder" prefHeight="720.0" minWidth="210.0" prefWidth="210.0" />
+                    <BorderPane fx:id="bp" prefHeight="720.0" styleClass="border-pane" HBox.hgrow="ALWAYS">
                         <top>
-                            <Pane BorderPane.alignment="CENTER">
+                            <VBox fx:id="topBox" prefHeight="150.0" styleClass="main-pane">
                                 <children>
-                                    <VBox fx:id="topBox" prefHeight="150.0" prefWidth="990.0" styleClass="main-pane">
-                                        <children>
-                                            <StackPane fx:id="commandBoxPlaceholder" focusTraversable="true" prefHeight="50.0" prefWidth="990.0" style="-fx-background-color: transparent;" VBox.vgrow="NEVER" />
-                                            <StackPane fx:id="divider" layoutX="10.0" layoutY="21.0" prefHeight="2.0" style="-fx-background-color: #33344B;" />
-                                            <StackPane fx:id="resultDisplayPlaceholder" prefHeight="73.0" prefWidth="990.0" style="-fx-background-color: transparent;" />
-                                        </children>
-                                    </VBox>
+                                    <StackPane fx:id="commandBoxPlaceholder" focusTraversable="true" prefHeight="50.0" style="-fx-background-color: transparent;" VBox.vgrow="NEVER" />
+                                    <StackPane fx:id="divider" layoutX="10.0" layoutY="21.0" prefHeight="2.0" style="-fx-background-color: #33344B;" />
+                                    <StackPane fx:id="resultDisplayPlaceholder" prefHeight="73.0" style="-fx-background-color: transparent;" />
                                 </children>
                                 <BorderPane.margin>
                                     <Insets left="30.0" right="30.0" top="30.0" />
                                 </BorderPane.margin>
-                            </Pane>
+                            </VBox>
                         </top>
                         <center>
-                            <StackPane fx:id="pagePlaceholder" prefHeight="150.0" prefWidth="200.0" BorderPane.alignment="CENTER">
+                            <StackPane fx:id="pagePlaceholder" prefHeight="150.0" BorderPane.alignment="TOP_LEFT">
                                 <BorderPane.margin>
                                     <Insets bottom="30.0" left="30.0" right="30.0" top="30.0" />
                                 </BorderPane.margin>

--- a/src/main/resources/view/OverviewPage.fxml
+++ b/src/main/resources/view/OverviewPage.fxml
@@ -24,7 +24,7 @@
                </padding>
             </StackPane>
 
-            <HBox fx:id="listheader" alignment="CENTER_LEFT" minHeight="-Infinity" prefHeight="50.0" prefWidth="480.0" spacing="10.0" style="-fx-background-color: #33344B;">
+            <HBox fx:id="personListHeader" alignment="CENTER_LEFT" minHeight="-Infinity" prefHeight="50.0" prefWidth="480.0" spacing="10.0" style="-fx-background-color: #33344B;">
                <children>
                   <Label fx:id="nm" maxHeight="17.0" maxWidth="17.0" minHeight="17.0" minWidth="17.0" prefHeight="17.0" prefWidth="17.0" text="#" textFill="WHITE" />
                   <Label fx:id="name" layoutX="35.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="Name" textFill="WHITE" />
@@ -57,7 +57,7 @@
                   <Insets left="20.0" />
                </padding>
             </StackPane>
-            <HBox fx:id="listheader1" alignment="CENTER_LEFT" prefHeight="50.0" prefWidth="380.0" spacing="10.0" style="-fx-background-color: #33344B;">
+            <HBox fx:id="jobListHeader" alignment="CENTER_LEFT" prefHeight="50.0" prefWidth="380.0" spacing="10.0" style="-fx-background-color: #33344B;">
                <children>
                   <Label fx:id="nm1" minHeight="30.0" minWidth="17.0" prefHeight="30.0" prefWidth="17.0" text="#" textFill="WHITE" />
                   <Label fx:id="name1" layoutX="35.0" layoutY="27.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="Description" textFill="WHITE" />

--- a/src/main/resources/view/OverviewPage.fxml
+++ b/src/main/resources/view/OverviewPage.fxml
@@ -9,7 +9,7 @@
    <children>
 
 
-      <VBox fx:id="personList" prefWidth="580.0" styleClass="main-pane"> <!-- bottom personlist -->
+      <VBox fx:id="personList" prefWidth="580.0" styleClass="main-pane" HBox.hgrow="always"> <!-- bottom personlist -->
          <children>
             <StackPane fx:id="headerSpace" alignment="CENTER_LEFT" focusTraversable="true" minHeight="-Infinity" prefHeight="60.0" style="-fx-background-color: transparent;">
                <children>
@@ -26,14 +26,14 @@
 
             <HBox fx:id="personListHeader" alignment="CENTER_LEFT" minHeight="-Infinity" prefHeight="50.0" prefWidth="480.0" spacing="10.0" style="-fx-background-color: #33344B;">
                <children>
-                  <Label fx:id="nm" maxHeight="17.0" maxWidth="17.0" minHeight="17.0" minWidth="17.0" prefHeight="17.0" prefWidth="17.0" text="#" textFill="WHITE" />
-                  <Label fx:id="name" layoutX="35.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="Name" textFill="WHITE" />
-                  <Label fx:id="name2" layoutX="47.0" layoutY="27.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="Unpaid" textFill="WHITE" />
-                  <Label fx:id="tags" layoutX="35.0" layoutY="27.0" maxWidth="65.0" minWidth="65.0" prefWidth="65.0" text="Tags" textFill="WHITE" />
-                  <Label fx:id="phone2" layoutX="262.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="Base Pay" textFill="WHITE" wrapText="true" />
-                  <Label fx:id="phone" layoutX="51.0" layoutY="27.0" maxWidth="70.0" minWidth="70.0" prefWidth="70.0" text="Phone" textFill="WHITE" wrapText="true" />
-                  <Label fx:id="email" layoutX="265.0" layoutY="27.0" maxWidth="70.0" minWidth="70.0" prefWidth="70.0" text="Mail" textFill="WHITE" wrapText="true" />
-                  <Label fx:id="address" layoutX="337.0" layoutY="27.0" maxWidth="59.0" minWidth="59.0" prefWidth="59.0" text="Address" textFill="WHITE" wrapText="true" />
+                  <Label fx:id="nm" minHeight="17.0" prefHeight="17.0" prefWidth="${personListHeader.width*0.034}" text="#" textFill="WHITE" />
+                  <Label fx:id="name" layoutX="35.0" layoutY="27.0" prefWidth="${personListHeader.width*0.12}" text="Name" textFill="WHITE" />
+                  <Label fx:id="name2" layoutX="47.0" layoutY="27.0" prefWidth="${personListHeader.width*0.2}" text="Unpaid" textFill="WHITE" />
+                  <Label fx:id="tags" layoutX="35.0" layoutY="27.0" prefWidth="${personListHeader.width*0.13}" text="Tags" textFill="WHITE" />
+                  <Label fx:id="phone2" layoutX="262.0" layoutY="27.0" prefWidth="${personListHeader.width*0.12}" text="Base Pay" textFill="WHITE" wrapText="true" />
+                  <Label fx:id="phone" layoutX="51.0" layoutY="27.0" prefWidth="${personListHeader.width*0.14}" text="Phone" textFill="WHITE" wrapText="true" />
+                  <Label fx:id="email" layoutX="265.0" layoutY="27.0" prefWidth="${personListHeader.width*0.14}" text="Mail" textFill="WHITE" wrapText="true" />
+                  <Label fx:id="address" layoutX="337.0" layoutY="27.0" prefWidth="${personListHeader.width*0.116}" text="Address" textFill="WHITE" wrapText="true" />
                </children>
                <padding>
                   <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
@@ -43,7 +43,7 @@
             <StackPane fx:id="personListPanelPlaceholder" prefHeight="3000.0" prefWidth="480.0" />
          </children>
       </VBox>
-      <VBox fx:id="personList1" layoutX="40.0" layoutY="40.0" prefWidth="380.0" styleClass="main-pane">
+      <VBox fx:id="personList1" layoutX="40.0" layoutY="40.0" prefWidth="380.0" styleClass="main-pane" HBox.hgrow="always">
          <children>
             <StackPane fx:id="commandBoxPlaceholder11" alignment="CENTER_LEFT" focusTraversable="true" minHeight="-Infinity" prefHeight="60.0" prefWidth="380.0" style="-fx-background-color: transparent;">
                <children>
@@ -59,12 +59,12 @@
             </StackPane>
             <HBox fx:id="jobListHeader" alignment="CENTER_LEFT" prefHeight="50.0" prefWidth="380.0" spacing="10.0" style="-fx-background-color: #33344B;">
                <children>
-                  <Label fx:id="nm1" minHeight="30.0" minWidth="17.0" prefHeight="30.0" prefWidth="17.0" text="#" textFill="WHITE" />
-                  <Label fx:id="name1" layoutX="35.0" layoutY="27.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="Description" textFill="WHITE" />
-                  <Label fx:id="phone1" layoutX="51.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="Duration" textFill="WHITE" wrapText="true" />
-                  <Label fx:id="email1" layoutX="265.0" layoutY="27.0" maxWidth="30.0" minWidth="30.0" prefWidth="30.0" text="Done" textFill="WHITE" wrapText="true" />
-                  <Label fx:id="tags1" layoutX="35.0" layoutY="27.0" maxWidth="30.0" minWidth="30.0" prefWidth="30.0" text="Paid" textFill="WHITE" />
-                  <Label fx:id="address1" layoutX="337.0" layoutY="27.0" minWidth="60.0" prefWidth="60.0" text="In Charge" textFill="WHITE" wrapText="true" />
+                  <Label fx:id="nm1" minHeight="30.0" minWidth="17.0" prefHeight="${jobListHeader.width*0.09375}" prefWidth="17.0" text="#" textFill="WHITE" />
+                  <Label fx:id="name1" layoutX="35.0" layoutY="27.0" prefWidth="${jobListHeader.width*0.3125}" text="Description" textFill="WHITE" />
+                  <Label fx:id="phone1" layoutX="51.0" layoutY="27.0" prefWidth="${jobListHeader.width*0.1875}" text="Duration" textFill="WHITE" wrapText="true" />
+                  <Label fx:id="email1" layoutX="265.0" layoutY="27.0" prefWidth="${jobListHeader.width*0.09375}" text="Done" textFill="WHITE" wrapText="true" />
+                  <Label fx:id="tags1" layoutX="35.0" layoutY="27.0" prefWidth="${jobListHeader.width*0.09375}" text="Paid" textFill="WHITE" />
+                  <Label fx:id="address1" layoutX="337.0" layoutY="27.0" prefWidth="${jobListHeader.width*0.21875}" text="In Charge" textFill="WHITE" wrapText="true" />
                </children>
                <padding>
                   <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -6,14 +6,14 @@
 
 <HBox alignment="CENTER_LEFT" prefWidth="475.0" spacing="10.0" styleClass="person-card" xmlns="http://javafx.com/javafx/11" xmlns:fx="http://javafx.com/fxml/1">
    <children>
-      <Label fx:id="idx" maxHeight="17.0" maxWidth="17.0" minHeight="17.0" minWidth="17.0" prefHeight="17.0" prefWidth="17.0" text="1" />
-      <Label fx:id="name" layoutX="35.0" layoutY="27.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="Nicole Lee Siying Rajara" wrapText="true" />
-      <Label fx:id="amtDue" layoutX="202.0" layoutY="37.0" maxWidth="100.0" minWidth="100.0" prefWidth="100.0" text="\$8888.88" wrapText="true" />
-      <FlowPane fx:id="tags" alignment="CENTER_LEFT" maxWidth="65.0" minWidth="65.0" prefWidth="65.0" prefWrapLength="50.0" />
-      <Label fx:id="basePay" layoutX="302.0" layoutY="37.0" maxWidth="60.0" minWidth="60.0" prefWidth="60.0" text="\$30/h" wrapText="true" />
-      <Label fx:id="phone" layoutX="51.0" layoutY="27.0" maxWidth="70.0" minWidth="70.0" prefWidth="70.0" text="62353535" wrapText="true" />
-      <Label fx:id="email" layoutX="265.0" layoutY="27.0" maxWidth="70.0" minWidth="70.0" prefWidth="70.0" text="nicole@staffhub.org" wrapText="true" />
-      <Label fx:id="address" layoutX="337.0" layoutY="27.0" maxWidth="59.0" minWidth="59.0" prefWidth="59.0" text="S888888 1 Tech Drive" wrapText="true" />
+      <Label fx:id="idx" minHeight="17.0" prefHeight="17.0" prefWidth="17.0" text="1" />
+      <Label fx:id="name" layoutX="35.0" layoutY="27.0" prefWidth="60.0" text="Nicole Lee Siying Rajara" wrapText="true" />
+      <Label fx:id="amtDue" layoutX="202.0" layoutY="37.0"  prefWidth="100.0" text="\$8888.88" wrapText="true" />
+      <FlowPane fx:id="tags" alignment="CENTER_LEFT" prefWidth="65.0" prefWrapLength="50.0" />
+      <Label fx:id="basePay" layoutX="302.0" layoutY="37.0" prefWidth="60.0" text="\$30/h" wrapText="true" />
+      <Label fx:id="phone" layoutX="51.0" layoutY="27.0" prefWidth="70.0" text="62353535" wrapText="true" />
+      <Label fx:id="email" layoutX="265.0" layoutY="27.0" prefWidth="70.0" text="nicole@staffhub.org" wrapText="true" />
+      <Label fx:id="address" layoutX="337.0" layoutY="27.0" prefWidth="59.0" text="S888888 1 Tech Drive" wrapText="true" />
    </children>
    <padding>
       <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -1,7 +1,7 @@
 {
   "guiSettings" : {
-    "windowWidth" : 1000.0,
-    "windowHeight" : 500.0,
+    "windowWidth" : 1400.0,
+    "windowHeight" : 800.0,
     "extra" : "some value ",
     "windowCoordinates" : {
       "x" : 300,

--- a/src/test/data/JsonUserPrefsStorageTest/UndersizedWindowUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/UndersizedWindowUserPref.json
@@ -1,7 +1,7 @@
 {
   "guiSettings" : {
-    "windowWidth" : 1400.0,
-    "windowHeight" : 800.0,
+    "windowWidth" : 1000.0,
+    "windowHeight" : 400.0,
     "windowCoordinates" : {
       "x" : 300,
       "y" : 100

--- a/src/test/java/peoplesoft/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/peoplesoft/storage/JsonUserPrefsStorageTest.java
@@ -57,6 +57,13 @@ public class JsonUserPrefsStorageTest {
     }
 
     @Test
+    public void readUserPrefs_windowTooSmall_minWindowSizeUsed() throws DataConversionException {
+        UserPrefs expected = getTypicalUserPrefsWithMinSizeWindow();
+        UserPrefs actual = readUserPrefs("UndersizedWindowUserPref.json").get();
+        assertEquals(expected, actual);
+    }
+
+    @Test
     public void readUserPrefs_valuesMissingFromFile_defaultValuesUsed() throws DataConversionException {
         UserPrefs actual = readUserPrefs("EmptyUserPrefs.json").get();
         assertEquals(new UserPrefs(), actual);
@@ -72,7 +79,14 @@ public class JsonUserPrefsStorageTest {
 
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
-        userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
+        userPrefs.setGuiSettings(new GuiSettings(1400, 800, 300, 100));
+        userPrefs.setAddressBookFilePath(Paths.get("addressbook.json"));
+        return userPrefs;
+    }
+
+    private UserPrefs getTypicalUserPrefsWithMinSizeWindow() {
+        UserPrefs userPrefs = new UserPrefs();
+        userPrefs.setGuiSettings(new GuiSettings(GuiSettings.MIN_WIDTH, GuiSettings.MIN_HEIGHT, 300, 100));
         userPrefs.setAddressBookFilePath(Paths.get("addressbook.json"));
         return userPrefs;
     }
@@ -103,7 +117,7 @@ public class JsonUserPrefsStorageTest {
     public void saveUserPrefs_allInOrder_success() throws DataConversionException, IOException {
 
         UserPrefs original = new UserPrefs();
-        original.setGuiSettings(new GuiSettings(1200, 200, 0, 2));
+        original.setGuiSettings(new GuiSettings(1400, 800, 0, 2));
 
         Path pefsFilePath = testFolder.resolve("TempPrefs.json");
         JsonUserPrefsStorage jsonUserPrefsStorage = new JsonUserPrefsStorage(pefsFilePath);


### PR DESCRIPTION
closes #156 #195 

- add min dimension constraints to GuiSettings creation (so, on deser and save)
- use min dimension fields in GuiSettings in MainWindow.fxml
- bind data col widths to header col widths
- use proportional prefWidths (to HBox width) for header cols
- allow border-pane, main-pane, job/employee lists to fill width

smol:
![image](https://user-images.githubusercontent.com/1695582/162569406-84baad42-74a1-40ea-adce-571a86d2febe.png)

wide:
![image](https://user-images.githubusercontent.com/1695582/162569411-3fccfd71-5f78-4f72-b823-e1cbf6f0c4ef.png)

@AY2122S2-CS2103T-T11-4/developers things to check:
- min window dimension constraints are respected on other desktop envs (my window manager doesn't respect them)
  - [ ] Windows
  - [ ] macOS
- idk lol